### PR TITLE
fix：review 等待期间 context 取消导致 goroutine 泄漏

### DIFF
--- a/agent/llm.go
+++ b/agent/llm.go
@@ -634,15 +634,22 @@ func StartStream(
 					reviewCh = make(chan bool, 1)
 				}
 				ch <- ToolCallStartMsg{Name: tc.Function.Name, Args: tc.Function.Arguments, ReviewCh: reviewCh}
-				if reviewCh != nil && !<-reviewCh {
-					ch <- ToolCallResultMsg{Name: tc.Function.Name, Output: "操作已被用户拒绝 (review 模式)", Success: false}
-					convo = append(convo, ChatMessage{
-						Role:       "tool",
-						ToolCallID: tc.ID,
-						Name:       tc.Function.Name,
-						Content:    "操作已被用户拒绝 (review 模式)",
-					})
-					continue
+				if reviewCh != nil {
+					select {
+					case approved := <-reviewCh:
+						if !approved {
+							ch <- ToolCallResultMsg{Name: tc.Function.Name, Output: "操作已被用户拒绝 (review 模式)", Success: false}
+							convo = append(convo, ChatMessage{
+								Role:       "tool",
+								ToolCallID: tc.ID,
+								Name:       tc.Function.Name,
+								Content:    "操作已被用户拒绝 (review 模式)",
+							})
+							continue
+						}
+					case <-ctx.Done():
+						return
+					}
 				}
 
 				var result tools.ToolResult

--- a/tui/model.go
+++ b/tui/model.go
@@ -1676,6 +1676,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.cancelAgent()
 					m.cancelAgent = nil
 				}
+				// 清理 reviewCh,防止 agent goroutine 泄漏
+				if m.reviewPending && m.reviewCh != nil {
+					m.reviewCh <- false
+					m.reviewPending = false
+					m.reviewCh = nil
+				}
 				if m.streamCh != nil {
 					drainAndDiscard(m.streamCh)
 				}
@@ -1688,6 +1694,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.cancelAgent != nil {
 					m.cancelAgent()
 					m.cancelAgent = nil
+				}
+				// 清理 reviewCh,防止 agent goroutine 泄漏
+				if m.reviewPending && m.reviewCh != nil {
+					m.reviewCh <- false
+					m.reviewPending = false
+					m.reviewCh = nil
 				}
 				if m.streamCh != nil {
 					drainAndDiscard(m.streamCh)
@@ -1720,6 +1732,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.cancelAgent != nil {
 					m.cancelAgent()
 					m.cancelAgent = nil
+				}
+				// 清理 reviewCh,防止 agent goroutine 泄漏
+				if m.reviewPending && m.reviewCh != nil {
+					m.reviewCh <- false
+					m.reviewPending = false
+					m.reviewCh = nil
 				}
 				drainAndDiscard(m.streamCh)
 				m.streamCh = nil


### PR DESCRIPTION
## 问题

用户在 review 等待期间按 Esc/Ctrl+C 取消时，agent goroutine 泄漏。

## 根因

**agent/llm.go:637** 使用裸 channel 接收：
```go
if reviewCh != nil && !<-reviewCh {  // 无人发送时永久阻塞
```

用户取消时：
1. TUI 调用 `cancelAgent()` → context 取消
2. TUI 排空 `streamCh` → 置 nil
3. 但 agent goroutine 仍阻塞在 `!<-reviewCh`
4. goroutine 无法退出 → 泄漏

## 修复（纵深防御）

### 1. Agent 端 - 允许 goroutine 退出
```go
if reviewCh != nil {
    select {
    case approved := <-reviewCh:
        if !approved { /* 拒绝 */ }
    case <-ctx.Done():
        return  // 退出 goroutine
    }
}
```

### 2. TUI 端 - 取消时清理 reviewCh
Esc/Ctrl+C 时，在排空 `streamCh` 前向 `reviewCh` 发送 `false`：
```go
if m.reviewPending && m.reviewCh != nil {
    m.reviewCh <- false
    m.reviewPending = false
    m.reviewCh = nil
}
```

两端配合确保无论时序如何都不会泄漏。

## 验证

- `go build` ✅
- `go vet` ✅
- `go test ./agent/... ./tui/...` ✅（测试通过）

## 关联

- 修复 bug 审计报告中的 BUG-3
- 与 BUG-2 同一场景，不同表现