### PR TITLE
fix(tui): reviewResultMsg 对 nil streamCh 缺少防护

### DIFF
--- a/tui/model.go
+++ b/tui/model.go
@@ -316,15 +316,15 @@ type webInputMsg struct{ text string }
 type webReviewMsg struct{ approve bool }
 
 // 控制类 web 消息:浏览器点按钮经 program.Send 注入,复用终端同一套切换逻辑。
-type webNewSessionMsg struct{}                // 新建会话
-type webSwitchSessionMsg struct{ id string }  // 切换到某会话
+type webNewSessionMsg struct{}                      // 新建会话
+type webSwitchSessionMsg struct{ id string }        // 切换到某会话
 type webRenameSessionMsg struct{ id, title string } // 重命名会话
-type webDeleteSessionMsg struct{ id string }  // 删除会话
-type webSetModelMsg struct{ role string }     // 路由 auto/flash/pro
-type webSetModeMsg struct{ mode string }      // 权限模式 plan/auto/review
-type webSetSandboxMsg struct{ mode string }   // 沙箱 off/native/docker
-type webSetWorkingModeMsg struct{ mode string } // 工作模式
-type webSetLangMsg struct{ lang string }        // 界面语言 zh/en
+type webDeleteSessionMsg struct{ id string }        // 删除会话
+type webSetModelMsg struct{ role string }           // 路由 auto/flash/pro
+type webSetModeMsg struct{ mode string }            // 权限模式 plan/auto/review
+type webSetSandboxMsg struct{ mode string }         // 沙箱 off/native/docker
+type webSetWorkingModeMsg struct{ mode string }     // 工作模式
+type webSetLangMsg struct{ lang string }            // 界面语言 zh/en
 
 // reviewResultMsg 审核完成后从 goroutine 发回,恢复流监听。
 type reviewResultMsg struct{}
@@ -2128,7 +2128,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case reviewResultMsg:
-		// 审核完成,恢复流监听继续工具循环
+		// 审核完成,恢复流监听继续工具循环。
+		// review 等待期间 API 连接断开时 streamCh 已被置 nil,此时应转入 idle。
+		if m.streamCh == nil {
+			return m, nil
+		}
 		return m, agent.ListenToStream(m.streamCh)
 
 	case skillSearchDoneMsg:


### PR DESCRIPTION
## Bug

reviewResultMsg 是异步 tea.Cmd 返回的消息，处理时无条件调用 agent.ListenToStream(m.streamCh)。若 streamCh 已被置 nil（正常退出路径或异常场景），ListenToStream(nil) 会永久阻塞在 <-nil，导致该轮监听状态异常。

## 复现

1. 切到 review 模式：/mode review
2. 触发一个需要 review 的操作（Write/Update/Bash）
3. review 等待期间 streamCh 被置 nil（如 agent goroutine 退出）
4. 用户按 Enter/Esc 审批或拒绝
5. reviewResultMsg 到达时 ListenToStream(nil) 永久阻塞

## 修复

streamCh 为 nil 时直接返回，不调用 ListenToStream。

## 测试

go test ./... : passed
