### PR TITLE
fix：后台进程 map 只增不减导致内存泄漏

### DIFF
--- a/tools/bg.go
+++ b/tools/bg.go
@@ -86,6 +86,14 @@ func startBackground(command, cwd string) ToolResult {
 		p.done = true
 		p.exitErr = werr
 		p.mu.Unlock()
+
+		// 延迟清理:进程退出 5 分钟后自动从 map 移除,防止 LLM 忘记调用 KillBash 导致内存泄漏。
+		// 5 分钟窗口足够让 LLM 读取最后输出(KillBash 会提前清理,不会等到这里)。
+		time.AfterFunc(5*time.Minute, func() {
+			bgMu.Lock()
+			delete(bgProcs, p.id)
+			bgMu.Unlock()
+		})
 	}()
 
 	return ToolResult{
@@ -129,6 +137,13 @@ func adoptBackground(cmd *exec.Cmd, buf *lockedBuffer, startedAt time.Time, wait
 		p.done = true
 		p.exitErr = werr
 		p.mu.Unlock()
+
+		// 延迟清理:进程退出 5 分钟后自动从 map 移除,防止内存泄漏。
+		time.AfterFunc(5*time.Minute, func() {
+			bgMu.Lock()
+			delete(bgProcs, p.id)
+			bgMu.Unlock()
+		})
 	}()
 	return id
 }


### PR DESCRIPTION
## 问题

`bgProcs` map 中的条目只在调用 `KillBash` 时移除。LLM 经常忘记调用 `KillBash`，导致已退出的进程条目永远残留，每个条目包含最大 256KB 的 `lockedBuffer`。

长时间会话内存持续增长。

## 根因

进程退出时的 goroutine 只设置 `p.done = true`，没有触发清理：

```go
go func() {
    werr := cmd.Wait()
    <-readerDone
    p.mu.Lock()
    p.done = true
    p.exitErr = werr
    p.mu.Unlock()
    // ❌ 没有清理逻辑
}()
```

唯一的清理路径是 LLM 主动调用 `KillBash`，但 LLM 经常忘记。

## 修复

在进程退出后，使用 `time.AfterFunc` 延迟 5 分钟自动清理：

```go
go func() {
    werr := cmd.Wait()
    <-readerDone
    p.mu.Lock()
    p.done = true
    p.exitErr = werr
    p.mu.Unlock()

    // ✅ 延迟清理：5 分钟后自动从 map 移除
    time.AfterFunc(5*time.Minute, func() {
        bgMu.Lock()
        delete(bgProcs, p.id)
        bgMu.Unlock()
    })
}()
```

5 分钟窗口足够让 LLM 读取最后输出，同时确保即使 `KillBash` 未被调用也能回收资源。

修复覆盖两条路径：
- `startBackground`（RunCommand 后台启动）
- `adoptBackground`（前台命令超时自动转后台）

## 验证

- `go build` ✅
- `go vet` ✅
- `go test ./tools/...` ✅（14 个测试通过）

## 关联

- 修复 bug 审计报告中的 BUG-7