### PR TITLE
✨ feat: 可切换显示模型思考过程(TUI + web)

### DIFF
--- a/tui/chat_log.go
+++ b/tui/chat_log.go
@@ -17,6 +17,7 @@ const (
 	kindAssistant = "assistant"
 	kindTools     = "tools"
 	kindSystem    = "system"
+	kindThinking  = "thinking" // 模型 reasoning_content,次级暗显(/thinking 开关)
 )
 
 // chatSegment 是 chatLog 的一格。

--- a/tui/i18n.go
+++ b/tui/i18n.go
@@ -169,6 +169,18 @@ var translations = map[string]map[Lang]string{
 		LangZH: "显示/隐藏右侧状态栏(也可按 Ctrl+B)",
 		LangEN: "Show/hide the right status panel (or press Ctrl+B)",
 	},
+	"cmd.thinking.desc": {
+		LangZH: "显示/隐藏模型思考过程(reasoning),暗显在对话流",
+		LangEN: "Show/hide the model's thinking (reasoning), dimmed in the chat",
+	},
+	"thinking.on": {
+		LangZH: "**已开启思考显示** — 之后回合会把模型的思考过程暗显在对话流(仅交互界面,不影响管道输出)。",
+		LangEN: "**Thinking display on** — the model's reasoning will show dimmed in the chat on following turns (interactive only, not piped output).",
+	},
+	"thinking.off": {
+		LangZH: "**已关闭思考显示** — 之后回合只用 spinner 表示思考,不再打印思考内容。",
+		LangEN: "**Thinking display off** — following turns show only a spinner while thinking, without printing the reasoning.",
+	},
 	"cmd.web-config.desc": {
 		LangZH: "配置 web 面板的绑定 IP 与端口(立即生效并显示新地址)",
 		LangEN: "Configure web dashboard bind IP & port (applied immediately, shows the new URL)",
@@ -327,6 +339,7 @@ var translations = map[string]map[Lang]string{
 			"- `/new` — 开启全新对话(当前对话已保存,可在 /sessions 找回)\n" +
 			"- `/sessions` — 历史对话列表(↑/↓ 选,Enter 切换)\n" +
 			"- `/status` — 显示/隐藏右侧状态栏(也可按 Ctrl+B)\n" +
+			"- `/thinking` — 显示/隐藏模型思考过程(reasoning)\n" +
 			"- `/web-config` — 配置 web 面板绑定 IP / 端口(局域网访问,立即生效并显示新地址)\n" +
 			"- `/sandbox` — 沙箱模式:`off`(关闭)/ `native`(OS 隔离,默认)/ `docker`(容器隔离)\n" +
 			"- `/working-mode` — 工作模式:`karpathy`(务实)/ `openspec`(规格驱动)/ `superpowers`(全流程严谨),默认 karpathy\n" +
@@ -361,6 +374,7 @@ var translations = map[string]map[Lang]string{
 			"- `/new` — Start a brand-new conversation (current one is saved, see /sessions)\n" +
 			"- `/sessions` — Conversation history (↑/↓ select, Enter switch)\n" +
 			"- `/status` — Show/hide the right status panel (or press Ctrl+B)\n" +
+			"- `/thinking` — Show/hide the model's thinking (reasoning)\n" +
 			"- `/web-config` — Configure web dashboard bind IP / port (LAN access, applied immediately, shows the new URL)\n" +
 			"- `/sandbox` — Sandbox mode: `off` / `native` (OS isolation, default) / `docker` (container isolation)\n" +
 			"- `/working-mode` — Working mode: `karpathy` (pragmatic) / `openspec` (spec-driven) / `superpowers` (rigorous), default karpathy\n" +

--- a/tui/meta.go
+++ b/tui/meta.go
@@ -26,6 +26,9 @@ type meta struct {
 	// HideStatus 记忆右侧状态栏的显隐选择(Ctrl+B / /status 切换),重启保持。
 	HideStatus bool `json:"hide_status,omitempty"`
 
+	// ShowThinking 记忆是否把模型思考(reasoning_content)暗显进对话流(/thinking 切换)。默认关。
+	ShowThinking bool `json:"show_thinking,omitempty"`
+
 	// Sandbox 记忆沙箱模式("native"/"docker",/sandbox 切换)。空 = native(默认)。
 	Sandbox string `json:"sandbox,omitempty"`
 	// SandboxDockerImage 记忆 docker 沙箱用的镜像(/sandbox docker <image>)。空 = ubuntu:24.04。

--- a/tui/model.go
+++ b/tui/model.go
@@ -307,6 +307,9 @@ type model struct {
 	// hideStatusPanel:隐藏右侧状态栏,chat 铺满整宽(Ctrl+B / /status 切换,记忆到 meta)。
 	hideStatusPanel bool
 
+	// showThinking:把模型 reasoning_content 暗显进对话流(/thinking 切换,记忆到 meta)。默认关。
+	showThinking bool
+
 	// docker 沙箱镜像拉取进度(/sandbox docker 切换时,镜像不在本地才拉)。
 	dockerPulling    bool
 	dockerPullImage  string
@@ -592,7 +595,8 @@ func initialModel(models agent.ModelConfig, needsSetup bool, version string, hub
 		mode:            agent.AgentMode_Auto,
 		workingMode:     agent.WorkingModeDefault, // 默认 kp;下方从 session 恢复
 		status:          "idle",
-		hideStatusPanel: metaGet().HideStatus, // 记忆上次的状态栏显隐
+		hideStatusPanel: metaGet().HideStatus,  // 记忆上次的状态栏显隐
+		showThinking:    metaGet().ShowThinking, // 记忆上次的思考显隐
 		spinner:         sp,
 		workspace:       wd,
 		setupInput:      si,
@@ -833,6 +837,14 @@ func endpointHost(models agent.ModelConfig) string {
 	return host
 }
 
+// onOff 把布尔映射成 web 控制事件用的 "on"/"off" 文本。
+func onOff(b bool) string {
+	if b {
+		return "on"
+	}
+	return "off"
+}
+
 // broadcastControlState 把全部控制态(权限模式 / 沙箱 / 工作模式 / 代码图谱 + 会话列表)
 // 推给 web,使浏览器状态栏与 TUI 对齐。启动时与每次切会话后调用。
 func (m model) broadcastControlState() {
@@ -845,6 +857,7 @@ func (m model) broadcastControlState() {
 	m.broadcast(web.Event{Kind: "sandbox", Text: string(tools.CurrentSandboxMode())})
 	m.broadcast(web.Event{Kind: "working_mode", Text: string(m.workingMode)})
 	m.broadcast(web.Event{Kind: "codegraph", Text: tools.CodeGraphStatus()})
+	m.broadcast(web.Event{Kind: "show_thinking", Text: onOff(m.showThinking)})
 	m.broadcastSessions()
 }
 
@@ -2326,12 +2339,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.streamCh == nil {
 			return m, nil
 		}
-		// 模型在思考。文字不进 chat,只确保 spinner 在转。重试成功后清掉重试提示。
+		// 模型在思考。默认只驱动 spinner;/thinking 打开后把 reasoning 增量暗显进 chat。
 		m.retryNotice = ""
 		m.status = "thinking"
 		if !m.thinking {
 			m.thinking = true
 			cmds = append(cmds, m.spinner.Tick)
+		}
+		if m.showThinking {
+			m.chatContent.EnsureKind(kindThinking, "")
+			m.chatContent.Append(string(msg))
+			m.refreshViewport()
 		}
 		return m, tea.Batch(append(cmds, agent.ListenToStream(m.streamCh))...)
 
@@ -3146,6 +3164,8 @@ func (m *model) handleSlashCommand(input string) tea.Cmd {
 		return m.startManualCompaction()
 	case "/status":
 		m.toggleStatusPanel()
+	case "/thinking":
+		m.toggleThinking()
 	case "/new":
 		m.startNewConversation()
 	case "/sessions":
@@ -3842,9 +3862,12 @@ func (m *model) renderChatBaseContent(w int) string {
 			return renderUserBubble(stripVS16(strings.TrimRight(ensureEmojiSpacing(raw), "\n")), width)
 		}
 		var inner string
-		if kind == kindTools {
+		switch kind {
+		case kindTools:
 			inner = colorizeDiffBlock(ensureEmojiSpacingANSI(ensureEmojiSpacing(raw)))
-		} else {
+		case kindThinking:
+			inner = dimThinking(ensureEmojiSpacing(raw), barInnerWidth(width, kind))
+		default:
 			inner = ensureEmojiSpacingANSI(m.renderMarkdown(ensureEmojiSpacing(raw), barInnerWidth(width, kind)))
 		}
 		inner = stripVS16(strings.TrimRight(inner, "\n"))

--- a/tui/palette.go
+++ b/tui/palette.go
@@ -39,6 +39,7 @@ func slashCommands() []struct{ name, desc string } {
 		{"/session-rename", T("cmd.sessionrename.desc")},
 		{"/session-delete", T("cmd.sessiondelete.desc")},
 		{"/status", T("cmd.status.desc")},
+		{"/thinking", T("cmd.thinking.desc")},
 		{"/web-config", T("cmd.web-config.desc")},
 		{"/sandbox", T("cmd.sandbox.desc")},
 		{"/working-mode", T("cmd.workingmode.desc")},

--- a/tui/session_modal.go
+++ b/tui/session_modal.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"deepx/agent"
+	"deepx/web"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -144,6 +145,20 @@ func (m *model) toggleStatusPanel() {
 	m.chatViewport.SetHeight(vpH)
 	m.input.SetWidth(leftW - inputGutterWidth) // 输入区跟着左列宽变化(状态栏显隐改变 leftW)
 	m.selecting = false
+	m.refreshViewport()
+}
+
+// toggleThinking 显隐"模型思考(reasoning_content)暗显"并记忆到 meta。
+// 只影响之后回合的思考渲染,不改已有段;给一条系统提示让用户知道当前状态。
+func (m *model) toggleThinking() {
+	m.showThinking = !m.showThinking
+	metaUpdate(func(mm *meta) { mm.ShowThinking = m.showThinking })
+	m.broadcast(web.Event{Kind: "show_thinking", Text: onOff(m.showThinking)}) // 同步给 web
+	if m.showThinking {
+		m.chatContent.Open(kindSystem, T("thinking.on"))
+	} else {
+		m.chatContent.Open(kindSystem, T("thinking.off"))
+	}
 	m.refreshViewport()
 }
 

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -42,6 +42,7 @@ var (
 	assistantBarColor = lipgloss.Color("141") // 淡紫
 	toolsBarColor     = lipgloss.Color("215") // 琥珀
 	systemBarColor    = lipgloss.Color("242") // 中灰
+	thinkingBarColor  = lipgloss.Color("240") // 暗灰,思考内容最弱视觉权重
 
 	// 用户回合做成"气泡":钢蓝底 + 白字 + 亮青块条,延续"用户=蓝"的语义,跟左对齐的 assistant/tools 错开。
 	userBubbleBg  = lipgloss.Color("24")  // 深钢蓝底
@@ -67,8 +68,23 @@ func barColorFor(kind string) color.Color {
 		return toolsBarColor
 	case kindSystem:
 		return systemBarColor
+	case kindThinking:
+		return thinkingBarColor
 	}
 	return systemBarColor
+}
+
+// dimThinking 把思考内容渲染成次级暗显(暗灰 + 斜体),并按 width 软换行。
+// 不走 glamour:思考是模型的内部独白,弱化显示避免抢正式回复的视觉焦点。
+func dimThinking(s string, width int) string {
+	if s == "" {
+		return ""
+	}
+	st := lipgloss.NewStyle().Foreground(thinkingBarColor).Italic(true)
+	if width > 0 {
+		st = st.Width(width)
+	}
+	return st.Render(s)
 }
 
 // applyQuoteBar 在已渲染 ANSI 文本左侧画一根色条,做两级引用。
@@ -89,7 +105,7 @@ func applyQuoteBar(content, kind string) string {
 		indent  string
 	)
 	switch kind {
-	case kindTools:
+	case kindTools, kindThinking:
 		barChar = "│" // 细线,作为二级 quote
 		indent = "  " // 2 列缩进,视觉上嵌入到上方 assistant 段
 	default:
@@ -134,7 +150,7 @@ func renderUserBubble(text string, viewportW int) string {
 // tools 段比一级段额外扣 2 列缩进。
 func barInnerWidth(viewportW int, kind string) int {
 	bar := barColWidthLevel1
-	if kind == kindTools {
+	if kind == kindTools || kind == kindThinking {
 		bar = barColWidthLevel2
 	}
 	w := viewportW - bar

--- a/web/hub.go
+++ b/web/hub.go
@@ -62,6 +62,10 @@ type Snapshot struct {
 	ReviewPending *ReviewInfo    `json:"reviewPending"`
 	AskQuestions  []agent.AskQuestion `json:"askQuestions"` // 非空 = 有待答选择题
 
+	// ShowThinking 是 /thinking 偏好,与 TUI 的 meta.ShowThinking 同步。打开时模型思考
+	// (reasoning_content)会作为 role=="thinking" 的消息内联进 Messages(排在其后的回复之前)。
+	ShowThinking bool `json:"showThinking,omitempty"`
+
 	// 控制态,与 TUI 对齐:路由 / 权限模式 / 沙箱 / 工作模式 / 代码图谱状态 + 会话列表。
 	Vendor      string        `json:"vendor"`      // 模型厂商(api host)
 	Routing     string        `json:"routing"`     // auto | flash | pro(模型路由 pin)
@@ -86,6 +90,7 @@ type Hub struct {
 	snap    Snapshot
 
 	openAssistant int // 当前正在流式的 assistant 消息下标;-1 表示没有
+	openThinking  int // 当前正在流式的 thinking 消息下标;-1 表示没有
 	toolSeq       int // 工具调用 ID 自增
 }
 
@@ -109,6 +114,7 @@ func NewHub(flashModel, proModel, workspace, lang string) *Hub {
 			WorkingMode: "karpathy",
 		},
 		openAssistant: -1,
+		openThinking:  -1,
 	}
 }
 
@@ -191,8 +197,10 @@ func (h *Hub) apply(ev Event) Event {
 		h.snap.AskQuestions = nil
 		h.snap.Streaming = true
 		h.openAssistant = -1
+		h.openThinking = -1
 
 	case "token":
+		h.openThinking = -1 // 正式回复开始,思考段结束
 		if h.openAssistant < 0 {
 			h.snap.Messages = append(h.snap.Messages, Message{Role: "assistant"})
 			h.openAssistant = len(h.snap.Messages) - 1
@@ -200,7 +208,16 @@ func (h *Hub) apply(ev Event) Event {
 		h.snap.Messages[h.openAssistant].Content += ev.Text
 
 	case "reasoning_token":
-		// 思考过程不进聊天气泡;前端可用它显示 "thinking…"。快照不存。
+		// 仅在 showThinking 打开时把思考内联成 role=="thinking" 消息(与 TUI 对称)。
+		// 内联进 Messages 而非单独字段:天然排在随后助手回复之前,且随快照重连不丢。
+		if h.snap.ShowThinking {
+			if h.openThinking < 0 {
+				h.snap.Messages = append(h.snap.Messages, Message{Role: "thinking"})
+				h.openThinking = len(h.snap.Messages) - 1
+				h.openAssistant = -1
+			}
+			h.snap.Messages[h.openThinking].Content += ev.Text
+		}
 
 	case "tool_call":
 		h.toolSeq++
@@ -214,6 +231,7 @@ func (h *Hub) apply(ev Event) Event {
 			Role: "tool", ID: id, Name: ev.Name, Args: ev.Args, Status: "running",
 		})
 		h.openAssistant = -1
+		h.openThinking = -1
 
 	case "tool_result":
 		// 配对到最近一个同名 running 工具。
@@ -278,10 +296,12 @@ func (h *Hub) apply(ev Event) Event {
 	case "done":
 		h.snap.Streaming = false
 		h.openAssistant = -1
+		h.openThinking = -1
 
 	case "error":
 		h.snap.Streaming = false
 		h.openAssistant = -1
+		h.openThinking = -1
 
 	case "ask_request":
 		h.snap.AskQuestions = ev.Questions
@@ -292,6 +312,8 @@ func (h *Hub) apply(ev Event) Event {
 		h.snap.Streaming = false
 		h.snap.ReviewPending = nil
 		h.snap.AskQuestions = nil
+		h.openAssistant = -1
+		h.openThinking = -1
 	case "review_request":
 		h.snap.ReviewPending = &ReviewInfo{Name: ev.Name, Args: ev.Args}
 
@@ -331,6 +353,13 @@ func (h *Hub) apply(ev Event) Event {
 	case "codegraph":
 		if ev.Text != "" {
 			h.snap.CodeGraph = ev.Text
+		}
+
+	case "show_thinking":
+		// 只影响之后的思考显示;已内联的 thinking 消息保留(对齐 TUI 的切换语义)。
+		h.snap.ShowThinking = ev.Text == "on"
+		if !h.snap.ShowThinking {
+			h.openThinking = -1
 		}
 
 	case "balance":

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -204,6 +204,8 @@ createApp({
       askSel: [],       // [题][选项] 勾选态
       // 活动状态行(对齐 TUI 输入框上方那条):状态 / 实时耗时 / 工具调用
       status: 'idle',   // idle | thinking | streaming | tool | error
+      showThinking: false, // /thinking 偏好,由快照 / show_thinking 事件与 TUI 同步
+      openThinkingIdx: -1, // 当前正在流式的 thinking 消息下标;-1 表示没有
       turnStart: 0,     // 本轮起始时间戳(ms)
       turnElapsed: 0,   // 上一轮总耗时(ms),非 streaming 时显示
       nowTick: 0,       // 由定时器刷新,驱动 streaming 时的实时耗时
@@ -680,10 +682,13 @@ createApp({
       if (s.workingMode) this.workingMode = s.workingMode;
       this.codegraph = s.codegraph || '';
       this.balance = s.balance || '';
+      this.showThinking = !!s.showThinking;
       this.sessions = s.sessions || [];
-      // 推断流式气泡:最后一条是 assistant 且还在 streaming 则继续往里追加
+      // 推断流式气泡:最后一条是 assistant / thinking 且还在 streaming 则继续往里追加
       const last = this.messages.length - 1;
-      this.openIdx = (this.streaming && last >= 0 && this.messages[last].role === 'assistant') ? last : -1;
+      const lastRole = last >= 0 ? this.messages[last].role : '';
+      this.openIdx = (this.streaming && lastRole === 'assistant') ? last : -1;
+      this.openThinkingIdx = (this.streaming && lastRole === 'thinking') ? last : -1;
       this.scrollDown();
     },
 
@@ -699,6 +704,7 @@ createApp({
           this.reviewPending = null;
           this.streaming = true;
           this.openIdx = -1;
+          this.openThinkingIdx = -1;
           // 状态行:开新一轮,起计时
           this.status = 'thinking';
           this.turnStart = Date.now();
@@ -706,6 +712,7 @@ createApp({
           this.nowTick = Date.now();
           break;
         case 'token':
+          this.openThinkingIdx = -1; // 正式回复开始,思考段结束
           if (this.openIdx < 0) {
             this.messages.push({ role: 'assistant', content: '' });
             this.openIdx = this.messages.length - 1;
@@ -715,12 +722,22 @@ createApp({
           break;
         case 'reasoning_token':
           this.status = 'thinking';
-          break; // 思考过程不入聊天
+          // 暗显思考流:内联成 thinking 消息,天然排在随后助手回复之前(对齐 TUI)
+          if (this.showThinking) {
+            if (this.openThinkingIdx < 0) {
+              this.messages.push({ role: 'thinking', content: '' });
+              this.openThinkingIdx = this.messages.length - 1;
+              this.openIdx = -1;
+            }
+            this.messages[this.openThinkingIdx].content += ev.text || '';
+          }
+          break;
         case 'tool_call':
           this.toolCalls.push({ id: ev.id, name: ev.name, args: ev.args || '', status: 'running', output: '' });
           // 内联进对话流;工具后另起 assistant 气泡。
           this.messages.push({ role: 'tool', id: ev.id, name: ev.name, args: ev.args || '', status: 'running', output: '' });
           this.openIdx = -1;
+          this.openThinkingIdx = -1;
           this.status = 'tool';
           break;
         case 'tool_result': {
@@ -764,6 +781,7 @@ createApp({
         case 'error':
           this.streaming = false;
           this.openIdx = -1;
+          this.openThinkingIdx = -1;
           // 冻结本轮总耗时,状态切到 完成 / 出错
           if (this.turnStart) this.turnElapsed = Date.now() - this.turnStart;
           this.status = ev.kind === 'error' ? 'error' : 'idle';
@@ -785,6 +803,7 @@ createApp({
         case 'interrupted':
           this.streaming = false;
           this.openIdx = -1;
+          this.openThinkingIdx = -1;
           this.reviewPending = null;
           this.askPending = null;
           this.askSel = [];
@@ -814,6 +833,10 @@ createApp({
           break;
         case 'codegraph':
           if (ev.text) this.codegraph = ev.text;
+          break;
+        case 'show_thinking':
+          // 只影响之后的思考显示;已内联的思考消息保留(对齐 TUI 的切换语义)
+          this.showThinking = ev.text === 'on';
           break;
         case 'balance':
           // 余额可能从有值变 "-"(切到不支持的供应商),直接覆盖,不用非空守卫。

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -87,6 +87,11 @@
               <div class="role">{{ t('you') }}</div>
               <div class="bubble user-text">{{ m.content }}</div>
             </template>
+            <!-- 思考过程暗显(/thinking 打开):内联在回复之前,次级弱化不抢焦点 -->
+            <template v-else-if="m.role === 'thinking'">
+              <div class="role">💭 {{ t('footer.thinking') }}</div>
+              <div class="bubble thinking-text">{{ m.content }}</div>
+            </template>
             <!-- AskUser 作答折叠档案:问题 + 已选答案,留在对话流里(issue #134) -->
             <template v-else-if="m.role === 'ask-record'">
               <div class="bubble ask-record md" v-html="render(m.content)"></div>

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -111,6 +111,15 @@ body {
 .md th, .md td { border: 1px solid var(--border); padding: 4px 8px; }
 .md blockquote { border-left: 3px solid var(--accent2); margin: 8px 0; padding-left: 12px; color: var(--dim); }
 
+/* 思考过程暗显:虚线左边框 + 暗色斜体,视觉权重最低,保留换行 */
+.msg.thinking .role { color: var(--dim); }
+.thinking-text {
+  background: transparent; border: none; border-left: 2px dashed var(--border);
+  border-radius: 0; padding: 2px 0 2px 12px;
+  color: var(--dim); font-style: italic; font-size: 13px;
+  white-space: pre-wrap; word-break: break-word;
+}
+
 /* 打字动画 */
 .typing { display: inline-flex; gap: 4px; }
 .typing span { width: 6px; height: 6px; border-radius: 50%; background: var(--dim); animation: blink 1.2s infinite; }

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -52,6 +52,46 @@ func TestHubApply(t *testing.T) {
 	}
 }
 
+// TestHubThinking 验证 /thinking 打开后 reasoning_token 内联成 thinking 消息,
+// 且排在随后助手回复之前;关闭时不产生 thinking 消息。
+func TestHubThinking(t *testing.T) {
+	// 打开思考:reasoning 先于 token,thinking 消息应排在 assistant 之前。
+	h := NewHub("f", "p", "/tmp/ws", "zh")
+	h.Broadcast(Event{Kind: "show_thinking", Text: "on"})
+	h.Broadcast(Event{Kind: "user_message", Text: "hi"})
+	h.Broadcast(Event{Kind: "reasoning_token", Text: "let me "})
+	h.Broadcast(Event{Kind: "reasoning_token", Text: "think"})
+	h.Broadcast(Event{Kind: "token", Text: "answer"})
+	h.Broadcast(Event{Kind: "done"})
+
+	s := h.SnapshotCopy()
+	if !s.ShowThinking {
+		t.Fatalf("ShowThinking should be true")
+	}
+	// user / thinking / assistant —— 思考排在回复之前。
+	if len(s.Messages) != 3 || s.Messages[0].Role != "user" ||
+		s.Messages[1].Role != "thinking" || s.Messages[2].Role != "assistant" {
+		t.Fatalf("messages order wrong: %+v", s.Messages)
+	}
+	if s.Messages[1].Content != "let me think" {
+		t.Fatalf("thinking content = %q, want %q", s.Messages[1].Content, "let me think")
+	}
+	if s.Messages[2].Content != "answer" {
+		t.Fatalf("assistant content = %q, want answer", s.Messages[2].Content)
+	}
+
+	// 关闭思考:reasoning_token 不入消息流。
+	h2 := NewHub("f", "p", "/tmp/ws", "zh")
+	h2.Broadcast(Event{Kind: "show_thinking", Text: "off"})
+	h2.Broadcast(Event{Kind: "user_message", Text: "hi"})
+	h2.Broadcast(Event{Kind: "reasoning_token", Text: "hidden"})
+	h2.Broadcast(Event{Kind: "token", Text: "answer"})
+	s2 := h2.SnapshotCopy()
+	if len(s2.Messages) != 2 || s2.Messages[1].Role != "assistant" {
+		t.Fatalf("thinking off should not add thinking msg: %+v", s2.Messages)
+	}
+}
+
 // TestHubAskQuestions 验证 AskUser 选择题在快照里的维护:ask_request 写入、ask_resolved 清空、
 // 新一轮 user_message 也清空(避免上一轮残留的待答问题串到下一轮)。
 func TestHubAskQuestions(t *testing.T) {


### PR DESCRIPTION
新增 /thinking 开关(默认关,记忆到 meta),打开后把模型 reasoning_content 暗显进对话流:
- TUI:新增 kindThinking 段,暗灰斜体 + 二级缩进细竖线,流式逐 token 追加
- web:reasoning 内联成 role=thinking 消息,排在随后助手回复之前;偏好经 show_thinking 事件与 TUI 双向同步,存快照支持刷新/重连
- exec/管道路径不受影响,始终不打印思考

agent 层零改动(reasoning_content 本就已解析并发到 TUI/web),仅补显示与开关。