### PR TITLE
🐛 fix: 终端不断吐出字面 "q" 字符 (#167)

### DIFF
--- a/tui/cursor_blink_test.go
+++ b/tui/cursor_blink_test.go
@@ -1,0 +1,55 @@
+package tui
+
+import "testing"
+
+// TestDetectAppSideCursorBlink:只有 VS Code 集成终端才 app 侧闪光标,其余交给终端。
+// 默认必须是 false —— 一旦回退成"所有终端都 app 侧闪",issue #167 的吐 q 就会复活。
+func TestDetectAppSideCursorBlink(t *testing.T) {
+	cases := []struct {
+		termProgram string
+		want        bool
+	}{
+		{"vscode", true},
+		{"Apple_Terminal", false},
+		{"iTerm.app", false},
+		{"WezTerm", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.termProgram, func(t *testing.T) {
+			t.Setenv("TERM_PROGRAM", c.termProgram)
+			if got := detectAppSideCursorBlink(); got != c.want {
+				t.Fatalf("TERM_PROGRAM=%q: detectAppSideCursorBlink() = %v, want %v", c.termProgram, got, c.want)
+			}
+		})
+	}
+}
+
+// TestCursorBlinkTickDoesNotToggleCursor:非 VS Code 终端下,600ms 心跳不得再切光标可见性。
+// 切一次 = bubbletea 重发一条 DECSCUSR("\x1b[N q"),在 CSI 解析不健全的终端上会漏出字面 q
+// (issue #167)。心跳本身仍要继续(它还驱动 codegraph 状态轮询与 workflow 计时重画)。
+func TestCursorBlinkTickDoesNotToggleCursor(t *testing.T) {
+	orig := appSideCursorBlink
+	defer func() { appSideCursorBlink = orig }()
+
+	appSideCursorBlink = false
+	m := model{}
+	for range 4 {
+		next, cmd := m.Update(cursorBlinkTickMsg{})
+		m = next.(model)
+		if m.cursorBlinkOff {
+			t.Fatal("非 app 侧闪烁的终端下,cursorBlinkOff 必须恒为 false(光标常驻,样式不变)")
+		}
+		if cmd == nil {
+			t.Fatal("cursorBlinkTick 心跳不能停:codegraph 状态轮询和 workflow 计时重画都搭它的车")
+		}
+	}
+
+	// VS Code:仍按原逻辑逐拍翻转,保住那边的闪烁手感。
+	appSideCursorBlink = true
+	m = model{}
+	next, _ := m.Update(cursorBlinkTickMsg{})
+	if !next.(model).cursorBlinkOff {
+		t.Fatal("VS Code 集成终端下 app 侧闪烁应照常翻转 cursorBlinkOff")
+	}
+}

--- a/tui/model.go
+++ b/tui/model.go
@@ -126,11 +126,11 @@ type model struct {
 	// Esc / 方向键 → 仅取消选择,不动 value。
 	inputAllSelected bool
 
-	// app 侧光标 blink 状态。textarea 现在用真实终端光标(SetVirtualCursor(false)),
-	// 终端光标 blink 走 DECSCUSR 指令但部分终端(如 VS Code 集成终端)不响应,
-	// 所以这里 600ms tick 自己切换 cursor 可见性 —— View 看到 cursorBlinkOff=true 时
-	// 不往 tea.View.Cursor 塞值,bubbletea 就把光标藏起来,下一拍切回来。
-	// 用户按键时由 Update 重置成"亮"并 reset 计时,保持手感跟旧虚拟光标一致。
+	// app 侧光标 blink 状态。textarea 用真实终端光标(SetVirtualCursor(false)),
+	// 而部分终端(VS Code 集成终端)不响应 DECSCUSR 的 blink 位,只好由 app 自己切
+	// cursor 可见性:View 看到 cursorBlinkOff=true 时不往 tea.View.Cursor 塞值。
+	// 但这条路径只在 appSideCursorBlink 为真时启用 —— 其余终端一律恒 false、光标常驻,
+	// 由终端自己闪(原因见 appSideCursorBlink,issue #167)。
 	cursorBlinkOff bool
 
 	// 命令 palette 选中索引。是否打开不存字段 — 由 filterSlashCommands(input value)
@@ -782,6 +782,24 @@ func cursorBlinkTick() tea.Cmd {
 	return tea.Tick(cursorBlinkInterval, func(time.Time) tea.Msg {
 		return cursorBlinkTickMsg{}
 	})
+}
+
+// appSideCursorBlink 决定光标由谁来闪:app 侧(切 tea.View.Cursor 的有无)还是终端自己。
+//
+// 默认交给终端(false)。因为 app 侧闪烁是靠把 tea.View.Cursor 置 nil 再塞回来实现的,
+// 而 bubbletea 只要发现光标样式变了就写一条 DECSCUSR(cursed_renderer.go):
+// nil → 样式 0、有值 → 样式 5,于是每 600ms 往终端写一次 "\x1b[5 q" / "\x1b[0 q"。
+// 这个序列的 q 前面有个空格(中间字节),CSI 解析器不健全的终端会在空格处就结束序列、
+// 把末尾的 q 当普通字符打印出来 —— 又因 bubbletea 是差分渲染不重画旧格子,这些野生的 q
+// 会从输入框光标处一路堆积(issue #167:每秒吐一个 q,拔键盘也不停)。
+// 光标常驻不变样式后,DECSCUSR 全程只在启停各写一次,问题消失。
+//
+// 例外:VS Code 集成终端默认忽略 DECSCUSR 的 blink 位(光标闪不闪由它自己的设置说了算),
+// 不 app 侧闪就是死光标;而它的 xterm.js 能正确吃掉中间字节、不会漏 q,所以只对它开这条路径。
+var appSideCursorBlink = detectAppSideCursorBlink()
+
+func detectAppSideCursorBlink() bool {
+	return os.Getenv("TERM_PROGRAM") == "vscode"
 }
 
 // broadcast 把事件发给 web hub(关闭时 hub==nil,直接跳过)。
@@ -2499,7 +2517,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case cursorBlinkTickMsg:
 		// app 侧 cursor blink:每 600ms 切一次可见,View 那边读 cursorBlinkOff
 		// 决定要不要把光标塞进 tea.View.Cursor。继续返回下一拍 tick,自驱动。
-		m.cursorBlinkOff = !m.cursorBlinkOff
+		// 仅 appSideCursorBlink 的终端走这条;其余恒 false,光标常驻交终端自己闪(issue #167)。
+		// 注意这拍 tick 不能停 —— 下面的 codegraph 状态轮询和 workflow 计时重画都搭它的车。
+		if appSideCursorBlink {
+			m.cursorBlinkOff = !m.cursorBlinkOff
+		}
 		// 顺带轮询代码图谱状态:后台异步变化(loading→ready),变了才广播给 web,保持与 TUI 对齐。
 		if m.hub != nil {
 			if cg := tools.CodeGraphStatus(); cg != m.lastCgStatus {

--- a/tui/view.go
+++ b/tui/view.go
@@ -407,8 +407,10 @@ func (m model) View() tea.View {
 	// textarea.Cursor() 给的 X/Y 是相对 textarea 自身的局部坐标;input 起始 Y =
 	// body 占的行数 + 顶部留白行数;X 要加上左侧 gutter 宽(textarea 现在从 gutter 右边起)。
 	// modal 打开时不显示真实光标 —— 避免光标卡在 modal 背后。
-	// cursorBlinkOff 由 cursorBlinkTickMsg 600ms 切一次:亮时塞 Cursor,灭时不塞 —
-	// 不依赖终端的 DECSCUSR blink 支持,VS Code 终端等也能闪。
+	// cursorBlinkOff 只在 appSideCursorBlink 的终端(VS Code)会翻转:亮时塞 Cursor、灭时不塞。
+	// 其余终端恒 false —— 光标常驻,由终端按 DECSCUSR 的 blink 位自己闪。
+	// 别为了闪烁再去切 Cursor 的有无:那会让 bubbletea 每拍重发 DECSCUSR,在 CSI 解析不健全的
+	// 终端上把序列末尾的 q 打印到屏幕上(issue #167,详见 model.go 的 appSideCursorBlink)。
 	if !m.showSetup && !m.showLangModal && !m.showWorkingModeModal && !m.showSandboxModal && !m.showProviderModal && !m.showMcpAdd && !m.showWebConfig && !m.showMcpDelete && !m.showSkillAdd && !m.showSkillDelete && !m.showSessionList && !m.reviewPending && !m.askPending && !m.cursorBlinkOff {
 		if c := m.input.Cursor(); c != nil {
 			c.Position.X += inputGutterWidth


### PR DESCRIPTION
Fixes #167

## 根因

app 侧光标闪烁是靠把 `tea.View.Cursor` 在 nil ↔ 有值之间来回切实现的(`tui/view.go`)。而 bubbletea 的渲染器只要发现光标样式变了,就写一条 DECSCUSR(`cursed_renderer.go`):

```go
// x/ansi
func SetCursorStyle(style int) string {
    return "\x1b[" + strconv.Itoa(style) + " q"   // 注意 q 前面是空格(中间字节)
}
```

Cursor 置 nil → 样式算 0,赋值(CursorBar + Blink)→ 样式 5。于是**每 600ms 就往终端写一次 `ESC [ 5 SP q` / `ESC [ 0 SP q`**。

CSI 解析不健全的终端会在那个空格处提前判定序列结束,把末尾的 `q` 当普通字符**打印**出来;bubbletea 又是差分渲染、不重画没变的格子,这些野生的 `q` 便从输入框光标处一路向右堆积 —— 对应 issue 里"启动即触发、约一秒一个、拔掉键盘也不停"的现象。

## 修法

默认让**光标常驻、样式恒定**,闪烁交回终端自己做(`Blink=true` 对应的 DECSCUSR 样式 5 本就是"闪烁竖条")。样式全程不变 → DECSCUSR 只在启动和退出各写一次,不再周期性重发。

仅对**默认忽略 DECSCUSR blink 位的 VS Code 集成终端**(`TERM_PROGRAM=vscode`)保留 app 侧闪烁 —— 它的 xterm.js 能正确解析中间字节、不会漏 `q`,那边手感不变。

600ms 心跳本身保持不变:codegraph 状态轮询与 workflow 计时重画仍搭它的车。

## 验证

把真实 bubbletea 渲染器接到内存 buffer 上,数它实际写出的 DECSCUSR 条数:

| | 跑 10 拍 | 跑 30 拍 | 跑 60 拍 |
|---|---|---|---|
| 旧行为(每拍切 Cursor 有无) | 4 | 10 | 18(随运行时间线性增长) |
| 本 PR(Cursor 常驻不变) | 2 | 2 | 2(启动/退出各一条,恒定) |

另加回归测试 `tui/cursor_blink_test.go`:非 VS Code 终端下心跳不得再翻转 `cursorBlinkOff`,且心跳 cmd 不能停。

`go build ./...` + linux/windows 交叉编译通过,`go vet` 干净,`go test ./tui/` 全绿。