### PR TITLE
fix(tui): normalize bare CR in padLinesToWidth to fix divider misalig…

### DIFF
--- a/tui/dashboard.go
+++ b/tui/dashboard.go
@@ -25,6 +25,17 @@ func padLinesToWidth(content string, w int) string {
 	if w <= 0 {
 		return content
 	}
+	// 历史区(agent 输出、工具结果、从会话文件载入的旧消息)里残留的裸 \r 会一路
+	// 透传到 uv 渲染层:uv 把裸 \r 当作"光标回到行首"(见 ultraviolet styled.go
+	// 的 printString:遇 \r 即 x = bounds.Min.X),后续字符覆盖本行前半段,
+	// 分隔线 ┃ 被顶到列 0 或错位,于是滚到那一条旧消息(固定滚动位置)时
+	// 就整行错乱。这个 \r 隐患之前只在输入框/粘贴入口兜过,历史展示路径漏了。
+	// 这里在"按 \n 切行 + 补/截列宽"之前统一归一化(\r\n 与单独的 \r 都转成 \n),
+	// 覆盖 chat / 输入框 / 排队区全部展示内容,从源头消除。
+	if strings.ContainsRune(content, '\r') {
+		content = strings.ReplaceAll(content, "\r\n", "\n")
+		content = strings.ReplaceAll(content, "\r", "\n")
+	}
 	lines := strings.Split(content, "\n")
 	for i, line := range lines {
 		cur := lineDisplayWidth(line)


### PR DESCRIPTION
…nment on old messages containing a lone carriage
 return
<img width="1733" height="804" alt="截图8" src="https://github.com/user-attachments/assets/d58b7d65-a486-48f3-ad61-9252daef405c" />
 
<img width="2550" height="1535" alt="截图9" src="https://github.com/user-attachments/assets/cfb598de-4915-41e5-a283-f64bcd2a80dd" />


  - Base（目标）：itmisx/deepx-code 的 main
  - Head（来源）：lordquest/deepx-code-feature-input-area-scrollable 的 fix/history-cr-divider
  - 改动规模：1 个提交、1 个文件 tui/dashboard.go（+11 行），基于上游 0c96a8a
  - 建议标题：fix(tui): 历史区滚到含裸 \r 的旧消息时分隔线错位

  问题根因

  聊天历史里某些旧消息（agent 输出、工具结果、从会话文件载入的内容）残留裸 \r（来自 \r\n 被按 \n 切分后残留，或单独的 \r）。

  deepx 用 ultraviolet 渲染，styled.go 的 printString 把孤立的 \r 当作「光标回到行首」（x = bounds.Min.X）。于是该行后续字符覆盖了前半段，分隔线 ┃ 被顶到列 0
  或错位——滚到那条旧消息（固定滚动位置）时整行错乱。

  之前只在新/粘贴输入框入口用 normalizeNewlines 兜过，padLinesToWidth（所有展示内容的统一出入口：chat / 输入框 / 排队区）漏了这层处理。