### PR TITLE
feat(tui): 长文本粘贴占位符 [Pasted text #N +X lines]

### DIFF
--- a/tui/model.go
+++ b/tui/model.go
@@ -37,6 +37,90 @@ var imagePlaceholderRe = regexp.MustCompile(`\[Image #(\d+)\]`)
 // 双击/点击时常有 1~2 格抖动,设 3 可把这种抖动挡在外面,只有真拖动才全选。
 const inputDragThreshold = 3
 
+// 长文本粘贴阈值:超过 800 字符,或超过一定行数(按视口高度动态)的文本,不直接塞进输入框,
+// 而是存全文、在输入框放占位符 [Pasted text #N +X lines]。
+// 与 free-code 一致:字符阈值用 PASTE_THRESHOLD=800;行数阈值 = min(height-10, pasteLineThresholdCap),
+// 常态终端(height 够大)下即 >2 行触发(见 free-code PromptInput.tsx:1220 的 maxLines = Math.min(rows-10, 2))。
+const pasteTextThreshold = 800
+const pasteLineThresholdCap = 2
+
+// pasteLineCap 与 free-code 一致:maxLines = min(rows-10, 2),常态终端下即 >2 行触发占位符。
+func (m model) pasteLineCap() int {
+	c := m.height - 10
+	if pasteLineThresholdCap < c {
+		c = pasteLineThresholdCap
+	}
+	return c
+}
+
+// formatPastedTextRef 生成长文本粘贴占位符,与 free-code 一致:[Pasted text #N +X lines]。
+func formatPastedTextRef(id, numLines int) string {
+	if numLines == 0 {
+		return fmt.Sprintf("[Pasted text #%d]", id)
+	}
+	return fmt.Sprintf("[Pasted text #%d +%d lines]", id, numLines)
+}
+
+// expandPastedTextRefs 把输入框里的 [Pasted text #N +X lines] 占位符展开回全文(发送前调用)。
+// 多个占位符反向替换(靠后的先替,保住前面偏移有效)。无对应存储的内容则保留占位符原样。
+func expandPastedTextRefs(input string, store map[int]string) string {
+	re := regexp.MustCompile(`\[Pasted text #(\d+)(?: \+\d+ lines)?\]`)
+	matches := re.FindAllStringSubmatchIndex(input, -1)
+	for i := len(matches) - 1; i >= 0; i-- {
+		m := matches[i]
+		idStr := input[m[2]:m[3]]
+		id := 0
+		for _, c := range idStr {
+			id = id*10 + int(c-'0')
+		}
+		full, ok := store[id]
+		if !ok {
+			continue
+		}
+		input = input[:m[0]] + full + input[m[1]:]
+	}
+	return input
+}
+
+// prunePastedTexts 回收已不再被引用的长文本粘贴全文,防止 pastedTexts 随会话无限增长(内存泄漏)。
+// 只要某 id 的占位符还出现在输入框 / 待发原始输入(pendingInputOriginal) / 排队输入(queuedInput)中
+// 就保留;否则该全文已随发送完成、打断回填等流程消费掉,可安全删除。(注意:不能"发送后无脑 delete",
+// 因为 Esc 打断会把 pendingInputOriginal 的占位符重新塞回输入框、需再次展开,那时还得靠 store。)
+func (m model) prunePastedTexts() {
+	if len(m.pastedTexts) == 0 {
+		return
+	}
+	refs := m.input.Value() + "\x00" + m.pendingInputOriginal
+	for _, q := range m.queuedInput {
+		refs += "\x00" + q
+	}
+	re := regexp.MustCompile(`\[Pasted text #(\d+)(?: \+\d+ lines)?\]`)
+	keep := make(map[int]bool, len(m.pastedTexts))
+	for _, sm := range re.FindAllStringSubmatch(refs, -1) {
+		id := 0
+		for _, c := range sm[1] {
+			id = id*10 + int(c-'0')
+		}
+		keep[id] = true
+	}
+	for id := range m.pastedTexts {
+		if !keep[id] {
+			delete(m.pastedTexts, id)
+		}
+	}
+}
+
+// normalizeNewlines 把 Windows(\r\n) / 老 Mac(\r) 换行统一成 \n。
+// 必须在文本进入 textarea 之前做:textarea 内置的 runeutil.Sanitizer 会把
+// \r 与 \n 各自替换成 \n,导致 \r\n 变成 \n\n(行被翻倍、历史/输入框显示错乱)。
+// 先归一化,textarea 就只会看到纯 \n,不再翻倍——与 free-code 在输入框组件层
+// (.replace(/\r/g, "\n")) 的做法一致。
+func normalizeNewlines(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return s
+}
+
 type model struct {
 	width  int
 	height int
@@ -110,6 +194,12 @@ type model struct {
 	inputHistory      []string
 	inputHistoryIndex int
 	inputDraft        string
+
+	// pastedTexts 存"长文本粘贴"的全文(按 id 索引);输入框里只放 [Pasted text #N +X lines]
+	// 占位符,避免超长文本被 textarea 的 CharLimit 截断、也不撑爆输入区。发送时再展开回全文。
+	// 参考 free-code 的 pastedContents 机制。短粘贴(< 阈值)不走这里,直接进输入框。
+	pastedTexts map[int]string
+	nextPasteID  int
 
 	currentReply *strings.Builder
 
@@ -229,9 +319,15 @@ type model struct {
 	shadowDonePct int
 	compactGen    int
 
-	// pendingUserText:本轮用户输入原文,发送时暂存、本轮成功后才写入 jsonl(连同 assistant)。
-	// 这样 503/失败/取消的轮次不会在 jsonl 里留下没有回复的孤儿 user 记录。
+	// pendingUserText:本轮用户输入「展开后的全文」,发送时暂存、本轮成功后才写入 jsonl
+	// (连同 assistant)。长文本粘贴在此已是展开态,落盘保存的是完整正文,正确。
+	// 注意:jsonl 要全文,但输入框回填(打断/中断时)绝不能填全文 —— 4000 上限的输入框
+	// 装不下 190 行,会被截断丢失。所以回填另用 pendingInputOriginal(见下)。
 	pendingUserText string
+	// pendingInputOriginal:本轮用户输入「原始形态」(含长文本粘贴占位符 [Pasted text #N +X lines],
+	// 未展开)。仅供「打断后回填输入框」使用,保持占位符形态避免塞爆输入框被截断。
+	// 与 pendingUserText 区分:后者展开后用于 jsonl 落盘,前者占位符用于输入框回填。
+	pendingInputOriginal string
 
 	// review 模式审核状态
 	reviewPending  bool
@@ -1002,6 +1098,20 @@ func (m *model) applyStaleShadow() {
 }
 
 func (m model) submitUserInput(input string) (model, tea.Cmd) {
+	// 暂存「原始输入」(含长文本粘贴占位符、未展开):专供打断后回填输入框,
+	// 必须保持占位符形态 —— 否则 190 行全文塞回 4000 上限的输入框会被截断、丢失。
+	// 展开后的全文另存 pendingUserText(下方),只用于本轮成功后的 jsonl 落盘。
+	m.pendingInputOriginal = input
+	// 发送前先回收已无引用的长文本全文(避免 pastedTexts 随会话累积泄漏)。
+	m.prunePastedTexts()
+	// 发送前把长文本粘贴占位符 [Pasted text #N +X lines] 展开回全文(参考 free-code)。
+	// 还原后可能远超过 textarea 的 CharLimit,但此时已离开输入框、直接送模型,不受限。
+	input = expandPastedTextRefs(input, m.pastedTexts)
+	// 粘贴文本可能含 Windows 换行 \r\n 或单独的 \r。\r\n 在后续渲染链里会被
+	// chatViewport.SetContentLines 拆成多行,但单独的 \r 会留在行尾被终端当回车符执行,
+	// 导致光标跳回行首、后续字符覆盖前面 → 视觉错乱(只在顶部旧消息出现、底部正常)。
+	// 输入时(PasteMsg 处理)已统一过一次,这里再兜一层,从源头消除。
+	input = normalizeNewlines(input)
 	input = strings.TrimSpace(input)
 	// 删掉输入框里的 [Image #N] = 想移除那张图:据残留占位符裁剪待发图片列表,
 	// 否则删了占位符图却照发、非视觉模型还会反复 OCR(issue #146 的「删不掉」)。
@@ -1015,7 +1125,9 @@ func (m model) submitUserInput(input string) (model, tea.Cmd) {
 	// (issue #161:web 生成中发送直接消失)。排队原文含斜杠命令时,popQueuedInput 回灌本函数时
 	// streaming 已置 false,会照常走下面的斜杠解析——与终端排队原文再解析的行为一致。
 	if m.streaming || m.compactingFG {
-		m.queuedInput = append(m.queuedInput, input)
+		// 排「原始输入」(占位符),不是已展开的全文——否则排队再回灌本函数时
+		// pendingInputOriginal 会拿到展开态,打断回填输入框又会塞爆被截断。
+		m.queuedInput = append(m.queuedInput, m.pendingInputOriginal)
 		m.broadcastQueued()
 		m.refreshViewport()
 		return m, nil
@@ -1310,7 +1422,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.showSetup || m.showLangModal || m.showWorkingModeModal || m.showModelModal || m.showSandboxModal || m.showReasoningModal || m.showSessionList || m.showProviderModal {
 			return m, nil
 		}
-		// 滚轮: 转给 viewport,顺便取消选区
+		// 滚轮:转给 viewport,顺便取消选区
 		if m.selecting {
 			m.selecting = false
 		}
@@ -1522,9 +1634,27 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		}
-		// 文本粘贴:让 textinput 处理
+		// 文本粘贴:超阈值(>800 字符,或行数超 pasteLineCap=min(height-10,2)、常态 >2 行)走占位符,否则让 textarea 正常接。
+		// 占位符方案避免超长文本被 textarea 的 CharLimit(4000)截断、也不撑爆输入区。
+		// 进入 textarea 之前先把 \r\n 归一为 \n:否则 textarea 的 Sanitizer 会把
+		// \r\n 拆成两个 \n(\r 一个、\n 一个),造成行翻倍、历史/输入框错乱(见 normalizeNewlines)。
+		text := msg.Content
+		text = normalizeNewlines(text)
+		numLines := strings.Count(text, "\n")
+		if len(text) > pasteTextThreshold || numLines > m.pasteLineCap() {
+			// 先回收上一轮已无引用的全文,再存新的;避免反复大段粘贴时 map 只增不减。
+			m.prunePastedTexts()
+			if m.pastedTexts == nil {
+				m.pastedTexts = make(map[int]string)
+			}
+			id := m.nextPasteID
+			m.nextPasteID++
+			m.pastedTexts[id] = text
+			m.input.InsertString(formatPastedTextRef(id, numLines))
+			return m, nil
+		}
 		var c tea.Cmd
-		m.input, c = m.input.Update(msg)
+		m.input, c = m.input.Update(tea.PasteMsg{Content: text})
 		return m, c
 
 	case tea.KeyPressMsg:
@@ -2266,12 +2396,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// 窗口内第二次:真正中断。
 				m.lastEscAt = time.Time{}
 				m = m.interruptStream()
-				// 打断后把这一轮的用户输入回填到空输入框,方便改一下重发。
-				// pendingUserText 是本轮原文(StreamDoneMsg 成功后才清空,所以打断时仍在);
-				// 仅当输入框为空时回填,不覆盖用户已敲入的新内容。
-				if strings.TrimSpace(m.input.Value()) == "" && m.pendingUserText != "" {
-					m.input.SetValue(m.pendingUserText)
-				}
+			// 打断后把这一轮的用户输入回填到空输入框,方便改一下重发。
+			// 用 pendingInputOriginal(原始形态、含粘贴占位符),不要用 pendingUserText
+			// (已展开的全文):190 行全文塞回 4000 上限的输入框会被截断、丢失。
+			// 仅当输入框为空时回填,不覆盖用户已敲入的新内容。
+			if strings.TrimSpace(m.input.Value()) == "" && m.pendingInputOriginal != "" {
+				m.input.SetValue(m.pendingInputOriginal)
+			}
 				m.refreshViewport()
 				return m, nil
 			}
@@ -2284,8 +2415,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.chatViewport, c = m.chatViewport.Update(msg)
 			return m, c
 		case "up":
-			// ↑ 键：光标在第一行（或输入框为空）时，翻阅上一条历史。
-			// 有弹窗/流式中/输入框非空且光标不在首行时不拦截，交给 textarea 处理光标移动。
+			// ↑ 键：光标在首行（或输入框为空）时，翻阅上一条历史。
+			// 有弹窗/流式中时不拦截，交给 textarea 处理光标移动。
 			if m.showSetup || m.showMcpAdd || m.showReasoningModal ||
 				m.showSkillAdd || m.showWebConfig || m.askPending || m.reviewPending {
 				// 弹窗打开时不拦截，让 textarea 处理

--- a/tui/paste_check_test.go
+++ b/tui/paste_check_test.go
@@ -1,0 +1,106 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/textarea"
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+)
+
+func initModel() model {
+	m := model{}
+	m.height = 30 // 常态终端高度,使 pasteLineCap = min(30-10,2) = 2,与 free-code 一致
+	m.width = 80
+	m.input = textarea.New()
+	m.input.Focus()
+	m.chatContent = newChatLog(1 << 20)
+	m.chatViewport = viewport.New()
+	m.currentReply = &strings.Builder{}
+	return m
+}
+
+// 造一段带 Windows 换行 \r\n 的粘贴文本。
+func crlfText(lines int) string {
+	raw := ""
+	for i := 0; i < lines; i++ {
+		raw += "行内容" + fmt.Sprint(i) + "\r\n"
+	}
+	return strings.TrimSuffix(raw, "\r\n")
+}
+
+// TestPasteSendShort:真正的"短粘贴"(行数<=2 且 <800 字节)走 textarea 正常路径,
+// 验证 \r\n 不再被 Sanitizer 翻成 \n\n(这是"历史/输入框错乱"的根因)。
+func TestPasteSendShort(t *testing.T) {
+	m := initModel()
+	// 3 行、2 个 \n、约 20 字节:行数(2)不超 pasteLineThreshold(2),
+	// 字节数远低于 pasteTextThreshold(800)→走短粘贴路径(不生成占位符)。
+	raw := "行A\r\n行B\r\n行C"
+	if len(raw) >= pasteTextThreshold {
+		t.Fatalf("测试构造错误:短粘贴样本 %d 字节 >= 阈值 %d", len(raw), pasteTextThreshold)
+	}
+	if strings.Count(raw, "\n") > m.pasteLineCap() {
+		t.Fatalf("测试构造错误:短粘贴样本行数 %d 超阈值 %d", strings.Count(raw, "\n"), m.pasteLineCap())
+	}
+
+	mm, _ := m.Update(tea.PasteMsg{Content: raw})
+	m = mm.(model)
+	t.Logf("输入框=%q  pastedTexts=%d", m.input.Value(), len(m.pastedTexts))
+	if len(m.pastedTexts) != 0 {
+		t.Errorf("❌ 短粘贴不应生成占位符: %q", m.input.Value())
+	}
+
+	em, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	m = em.(model)
+
+	chat := m.chatContent.String()
+	t.Logf("chatContent=%q", chat)
+	if strings.Contains(chat, "[Pasted text #") {
+		t.Errorf("❌ 聊天历史区仍是占位符: %q", chat)
+	}
+	if !strings.Contains(chat, "行A") || !strings.Contains(chat, "行C") {
+		t.Errorf("❌ 聊天历史区未包含正文: %q", chat)
+	}
+	if strings.Contains(chat, "\n\n") {
+		t.Errorf("❌ 仍存在翻倍换行 \\n\\n(历史/输入框会错乱): %q", chat)
+	}
+	if strings.Contains(chat, "\r") {
+		t.Errorf("❌ 仍残留 \\r: %q", chat)
+	}
+}
+
+// TestPasteSendLong:长粘贴(>800 字符)走占位符,验证发送时展开为全文且 \r\n 已归一。
+func TestPasteSendLong(t *testing.T) {
+	m := initModel()
+	raw := crlfText(200) // 远超阈值
+	if len(raw) <= pasteTextThreshold {
+		t.Fatalf("测试构造错误:长粘贴样本 %d 字节 <= 阈值 %d", len(raw), pasteTextThreshold)
+	}
+
+	mm, _ := m.Update(tea.PasteMsg{Content: raw})
+	m = mm.(model)
+	t.Logf("输入框=%q  pastedTexts=%d", m.input.Value(), len(m.pastedTexts))
+	if !strings.Contains(m.input.Value(), "[Pasted text #") {
+		t.Errorf("❌ 长粘贴未生成占位符: %q", m.input.Value())
+	}
+
+	em, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	m = em.(model)
+
+	chat := m.chatContent.String()
+	t.Logf("chatContent=%q", chat)
+	if strings.Contains(chat, "[Pasted text #") {
+		t.Errorf("❌ 聊天历史区仍是占位符,发送时展开未生效: %q", chat)
+	}
+	if !strings.Contains(chat, "行内容199") {
+		t.Errorf("❌ 聊天历史区未包含展开后的全文: %q", chat)
+	}
+	if strings.Contains(chat, "\n\n") {
+		t.Errorf("❌ 仍存在翻倍换行 \\n\\n: %q", chat)
+	}
+	if strings.Contains(chat, "\r") {
+		t.Errorf("❌ 仍残留 \\r: %q", chat)
+	}
+}

--- a/tui/paste_nav_test.go
+++ b/tui/paste_nav_test.go
@@ -1,0 +1,91 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// 复现并修复:"粘贴长文本→发送→打断→上翻(占位符正确)→下翻(不应展开截断全文)"。
+// 根因:pendingUserText 存的是「展开后的全文」,打断回填输入框时把 190 行全文塞回
+// 4000 上限的输入框被截断;随后上翻记下这个全文作 draft,下翻恢复 draft → 全文显示在输入区。
+// 修复:回填用占位符形态 pendingInputOriginal,jsonl 仍落全文(pendingUserText)。
+func TestPasteInterruptRefillKeepsPlaceholder(t *testing.T) {
+	m := initModel()
+	m.streamCh = make(chan tea.Msg) // 打断路径需要非空 streamCh
+
+	// 1) 粘贴 190 行长文本 → 占位符
+	raw := crlfText(190)
+	mm, _ := m.Update(tea.PasteMsg{Content: raw})
+	m = mm.(model)
+	ph := m.input.Value() // "[Pasted text #0 +189 lines]"
+	if !strings.Contains(ph, "[Pasted text #0") {
+		t.Fatalf("前置失败:长粘贴未生成占位符: %q", ph)
+	}
+	t.Logf("[paste] input=%q", ph)
+
+	// 2) 回车发送(此时 streaming=true,pendingUserText=全文,pendingInputOriginal=占位符)
+	em, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	m = em.(model)
+	t.Logf("[enter] streaming=%v pendingInputOriginal=%q pendingUserText.len=%d",
+		m.streaming, m.pendingInputOriginal, len(m.pendingUserText))
+
+	// 3) 连续两次 Esc(窗口内)→ 打断,回填输入框
+	mm2, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEsc}))
+	m = mm2.(model)
+	mm3, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEsc}))
+	m = mm3.(model)
+	t.Logf("[interrupt] input=%q streaming=%v", m.input.Value(), m.streaming)
+
+	got := m.input.Value()
+	if strings.Contains(got, "\n") && len(got) > 200 {
+		t.Errorf("❌ 打断回填把展开的全文塞回输入框(被截断/撑爆):\nlen=%d head=%q",
+			len(got), firstN(got, 60))
+	}
+	if got != ph {
+		t.Errorf("❌ 打断回填应为占位符 %q,实际 %q", ph, got)
+	}
+
+	// 4) 上翻:召回历史(占位符,正确)
+	um, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyUp}))
+	m = um.(model)
+	t.Logf("[up] input=%q idx=%d draft=%q", m.input.Value(), m.inputHistoryIndex, m.inputDraft)
+	if !strings.Contains(m.input.Value(), "[Pasted text #0") {
+		t.Errorf("❌ 上翻应显示占位符,实际 %q", m.input.Value())
+	}
+
+	// 5) 下翻:退出翻阅,应恢复占位符(draft),绝不可是展开的全文。
+	dm, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+	m = dm.(model)
+	t.Logf("[down] input=%q idx=%d", m.input.Value(), m.inputHistoryIndex)
+	if strings.Contains(m.input.Value(), "\n") && len(m.input.Value()) > 200 {
+		t.Errorf("❌ 下翻把全文展开截断进输入框: len=%d", len(m.input.Value()))
+	}
+	if m.input.Value() != ph {
+		t.Errorf("❌ 下翻应恢复占位符 %q,实际 %q", ph, m.input.Value())
+	}
+}
+
+// 确认 jsonl 落盘路径仍拿「展开后的全文」(pendingUserText),不被占位符污染。
+func TestPastePendingUserTextIsFull(t *testing.T) {
+	m := initModel()
+	raw := crlfText(190)
+	mm, _ := m.Update(tea.PasteMsg{Content: raw})
+	m = mm.(model)
+	em, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	m = em.(model)
+	if !strings.Contains(m.pendingUserText, "行内容0") || strings.Contains(m.pendingUserText, "[Pasted text #") {
+		t.Errorf("❌ pendingUserText 应已展开为全文,实际 head=%q", firstN(m.pendingUserText, 40))
+	}
+	if m.pendingInputOriginal == "" || strings.Contains(m.pendingInputOriginal, "行内容0") {
+		t.Errorf("❌ pendingInputOriginal 应保持占位符形态,实际 %q", m.pendingInputOriginal)
+	}
+}
+
+func firstN(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/tui/paste_ref_test.go
+++ b/tui/paste_ref_test.go
@@ -1,0 +1,123 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatPastedTextRef(t *testing.T) {
+	if got := formatPastedTextRef(1, 0); got != "[Pasted text #1]" {
+		t.Fatalf("numLines=0: got %q", got)
+	}
+	if got := formatPastedTextRef(3, 12); got != "[Pasted text #3 +12 lines]" {
+		t.Fatalf("numLines>0: got %q", got)
+	}
+}
+
+func TestExpandPastedTextRefs(t *testing.T) {
+	store := map[int]string{
+		1: "line1\nline2\nline3",
+		2: "alpha\nbeta\n",
+	}
+	// 单占位符
+	if got := expandPastedTextRefs("[Pasted text #1 +2 lines]", store); got != "line1\nline2\nline3" {
+		t.Fatalf("single: got %q", got)
+	}
+	// 多占位符(混合文本),验证顺序与偏移
+	in := "head [Pasted text #1 +2 lines] mid [Pasted text #2 +1 lines] tail"
+	want := "head line1\nline2\nline3 mid alpha\nbeta\n tail"
+	if got := expandPastedTextRefs(in, store); got != want {
+		t.Fatalf("multi: got %q want %q", got, want)
+	}
+	// 无对应存储 → 保留占位符原样
+	if got := expandPastedTextRefs("[Pasted text #9 +5 lines]", store); got != "[Pasted text #9 +5 lines]" {
+		t.Fatalf("missing: got %q", got)
+	}
+}
+
+// TestPasteThresholdLogic 验证触发占位符的判定与 free-code 一致:>800 字符或 >2 行。
+func TestPasteThresholdLogic(t *testing.T) {
+	// 与源码一致:行数阈值 = min(h-10, pasteLineThresholdCap);常态终端 h=30 → 2。
+	check := func(text string, h int) bool {
+		c := h - 10
+		if pasteLineThresholdCap < c {
+			c = pasteLineThresholdCap
+		}
+		return len(text) > pasteTextThreshold || strings.Count(text, "\n") > c
+	}
+	// 短单行 → 不触发
+	if check("hello world", 30) {
+		t.Fatal("short single line should NOT trigger")
+	}
+	// 恰好 800 字符、1 行 → 不触发(严格大于)
+	if check(strings.Repeat("a", 800), 30) {
+		t.Fatal("exactly 800 chars, 1 line should NOT trigger")
+	}
+	// 801 字符 → 触发
+	if !check(strings.Repeat("a", 801), 30) {
+		t.Fatal("801 chars should trigger")
+	}
+	// 4 行(3 个换行) → 触发(free-code: numLines>2 才占位)
+	if !check("a\nb\nc\nd", 30) {
+		t.Fatal("4 lines (3 newlines) should trigger")
+	}
+	// 3 行(2 个换行) → 不触发
+	if check("a\nb\nc", 30) {
+		t.Fatal("3 lines (2 newlines) should NOT trigger")
+	}
+	// 2 行(1 个换行) → 不触发
+	if check("a\nb", 30) {
+		t.Fatal("2 lines should NOT trigger")
+	}
+	// 矮终端(height=11 → cap=1):2 个换行(3 行)也会触发(numLines>1)
+	if !check("a\nb\nc", 11) {
+		t.Fatal("short terminal (h=11,cap=1) should trigger on 2 newlines")
+	}
+}
+
+// TestPrunePastedTexts 验证回收逻辑:只删"占位符已无处引用"的条目,
+// 保留仍在 input / pendingInputOriginal / queuedInput 中的 id(尤其 Esc 打断回填路径依赖 pendingInputOriginal)。
+func TestPrunePastedTexts(t *testing.T) {
+	// 场景1:input 含 id1、id2 占位符,id3 无引用 → 只留 1、2
+	m := initModel()
+	m.pastedTexts = map[int]string{1: "full1", 2: "full2", 3: "full3"}
+	m.input.SetValue("[Pasted text #1] keep [Pasted text #2]")
+	m.pendingInputOriginal = ""
+	m.queuedInput = nil
+	m.prunePastedTexts()
+	if len(m.pastedTexts) != 2 {
+		t.Fatalf("场景1:期望保留 2 条,实际 %d: %v", len(m.pastedTexts), m.pastedTexts)
+	}
+	if _, ok := m.pastedTexts[3]; ok {
+		t.Errorf("❌ 未回收无引用的 id3")
+	}
+	if _, ok := m.pastedTexts[1]; !ok {
+		t.Errorf("❌ 误删仍在 input 的 id1")
+	}
+
+	// 场景2:input 空,但 pendingInputOriginal 含 id1(模拟 Esc 打断回填前状态)
+	// → id1 必须保留,无引用的 id2 回收。
+	m2 := initModel()
+	m2.pastedTexts = map[int]string{1: "full1", 2: "full2"}
+	m2.input.SetValue("")
+	m2.pendingInputOriginal = "[Pasted text #1]"
+	m2.queuedInput = nil
+	m2.prunePastedTexts()
+	if _, ok := m2.pastedTexts[1]; !ok {
+		t.Errorf("❌ 误删 pendingInputOriginal 引用的 id1(Esc 回填会丢字)")
+	}
+	if _, ok := m2.pastedTexts[2]; ok {
+		t.Errorf("❌ 未回收无引用的 id2")
+	}
+
+	// 场景3:占位符数字与 store id 不一致 → 不匹配的 id 应被回收
+	m3 := initModel()
+	m3.pastedTexts = map[int]string{5: "full5"}
+	m3.input.SetValue("[Pasted text #9 +3 lines]") // id9 无存储
+	m3.pendingInputOriginal = ""
+	m3.queuedInput = nil
+	m3.prunePastedTexts()
+	if len(m3.pastedTexts) != 0 {
+		t.Fatalf("场景3:占位符 id9 无存储,store 应清空,实际 %v", m3.pastedTexts)
+	}
+}

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 const (
@@ -222,7 +223,16 @@ func renderUserBubble(text string, viewportW int) string {
 		Width(boxW).
 		Padding(0, 1)
 	bar := lipgloss.NewStyle().Foreground(userBubbleBar).Render("┃")
-	lines := strings.Split(box.Render(text), "\n")
+	// lipgloss 的 Width 只做按词边界的软折行:超长无空格单行(日志/JSON/minified 代码)
+	// 找不到断词点就不硬断,会横向溢出 chat 区。再套一层 ansi.Wrap 做硬折行兜底,
+	// 任何超宽行都被强制断到内容区宽内(box 带左右 Padding(0,1) 各 1 列,内容宽 = boxW-2),
+	// 与模型回复走 glamour 的一致,避免粘贴长文本后错乱。
+	innerW := boxW - 2
+	if innerW < 1 {
+		innerW = 1
+	}
+	rendered := ansi.Wrap(box.Render(text), innerW, "")
+	lines := strings.Split(rendered, "\n")
 	for i, ln := range lines {
 		lines[i] = bar + ln
 	}

--- a/tui/tool_display_test.go
+++ b/tui/tool_display_test.go
@@ -1,11 +1,26 @@
 package tui
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// updatePreviewArgs 用 json.Marshal 构造 Update 工具的 args,
+// 由标准库自动转义路径里的反斜杠,避免 Windows 上手写 JSON 因 \U/\s 非法转义导致 json.Unmarshal 失败。
+func updatePreviewArgs(path, oldS, newS string) string {
+	b, err := json.Marshal(map[string]string{
+		"path":       path,
+		"old_string": oldS,
+		"new_string": newS,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
 
 // TestUpdatePreviewLineNumbers 字符串模式 + 文件可读:locateLineInFile 反推出行号,
 // old/new 块都带行号。
@@ -15,7 +30,7 @@ func TestUpdatePreviewLineNumbers(t *testing.T) {
 	if err := os.WriteFile(path, []byte("line1\nline2\nline3\nline4\n"), 0o644); err != nil {
 		t.Fatalf("write sample: %v", err)
 	}
-	args := `{"path":"` + path + `","old_string":"line2\nline3","new_string":"newA\nnewB"}`
+	args := updatePreviewArgs(path, "line2\nline3", "newA\nnewB")
 	out := formatUpdatePreview(args)
 	if !strings.Contains(out, "2 - line2") {
 		t.Errorf("expected '2 - line2', got:\n%s", out)
@@ -33,7 +48,7 @@ func TestUpdatePreviewLineNumbers(t *testing.T) {
 
 // TestUpdatePreviewNoLineInfo 文件读不到 / 没匹配:退化成无行号渲染。
 func TestUpdatePreviewNoLineInfo(t *testing.T) {
-	args := `{"path":"/nonexistent/file.txt","old_string":"foo","new_string":"bar"}`
+	args := updatePreviewArgs("/nonexistent/file.txt", "foo", "bar")
 	out := formatUpdatePreview(args)
 	if !strings.Contains(out, "- foo") {
 		t.Errorf("expected '- foo' fallback, got:\n%s", out)

--- a/tui/user_bubble_test.go
+++ b/tui/user_bubble_test.go
@@ -1,0 +1,41 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// TestRenderUserBubbleNoOverflow 验证用户消息里的超长无空格单行(日志/JSON/minified
+// 代码)会被硬折行到 boxW 以内,不会横向溢出 chat 区。这是粘贴长文本的回归点。
+func TestRenderUserBubbleNoOverflow(t *testing.T) {
+	const viewportW = 40
+	longNoSpace := strings.Repeat("x", 200) // 200 字符无空格,远超 boxW
+	out := renderUserBubble(longNoSpace, viewportW)
+
+	// 去掉 ANSI 后逐行检查显示宽度 <= boxW(boxW = viewportW-1)
+	boxW := viewportW - 1
+	maxW := 0
+	for _, line := range strings.Split(out, "\n") {
+		plain := ansi.Strip(line)
+		w := ansi.StringWidth(plain)
+		if w > maxW {
+			maxW = w
+		}
+	}
+	if maxW > boxW {
+		t.Fatalf("line display width %d exceeds boxW %d (overflow)", maxW, boxW)
+	}
+	if maxW == 0 {
+		t.Fatal("empty output")
+	}
+}
+
+// TestRenderUserBubbleNormalText 验证普通带空格文本仍正常按行渲染。
+func TestRenderUserBubbleNormalText(t *testing.T) {
+	out := renderUserBubble("hello world\nsecond line", 40)
+	if !strings.Contains(out, "hello world") || !strings.Contains(out, "second line") {
+		t.Fatalf("normal text lost: %q", out)
+	}
+}


### PR DESCRIPTION
粘贴超阈值(>800 字符,或行数超 min(height-10,2)、常态 >2 行)的文本,
不直接塞进输入框(避免被 textarea 的 CharLimit(4000) 截断、撑爆输入区), 而是存全文、在输入框放占位符 [Pasted text #N +X lines],发送前展开回全文。

- 与 free-code 一致:字符阈值 PASTE_THRESHOLD=800;行数阈值 = min(height-10,2)。
- 发送前 normalizeNewlines 统一 \r\n/\r → \n,消除旧消息光标错乱根因。
- Esc 打断回填用 pendingInputOriginal(占位符形态),不丢字。
- renderUserBubble 用 ansi.Wrap 硬折行,超长无空格文本(JSON/minified)不再溢出 chat 区。
- 内存:prunePastedTexts 回收已无引用的粘贴全文(map 不再随会话无限增长); 仅删占位符已不在 input/pendingInputOriginal/queuedInput 中的 id,打断回填路径安全。

Test: paste_ref_test / paste_nav_test / paste_check_test / user_bubble_test

附:顺手修 tui/tool_display_test.go 的 Windows 专属测试 bug —— TestUpdatePreviewLineNumbers 把手写 JSON 里 t.TempDir() 的 Windows 反斜杠路径 直接拼接,产生非法 JSON 转义(\U/\s)导致 json.Unmarshal 失败、断言全挂; 改用 json.Marshal 构造 args。Linux 上 TempDir 是正斜杠故原本通过,属预存测试缺陷, 与本次功能无关。

_test.go 归属(相对基准 0c96a8a / 作者主干):
- 新增(paste 功能配套测试,主干原本没有): tui/paste_ref_test.go / tui/paste_nav_test.go / tui/paste_check_test.go / tui/user_bubble_test.go
- 改已有(主干本就有,仅修其 TestUpdatePreviewLineNumbers 的 Windows JSON 构造): tui/tool_display_test.go 即除 tool_display_test.go 外,本提交涉及的测试文件均为 PR2 新加,不动主干既有测试。