### PR TITLE
🐛 fix(tui): 用户气泡去掉 ansi.Wrap 二次折行(修 #186 回归)

### DIFF
--- a/tui/styles.go
+++ b/tui/styles.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/charmbracelet/x/ansi"
 )
 
 const (
@@ -223,16 +222,11 @@ func renderUserBubble(text string, viewportW int) string {
 		Width(boxW).
 		Padding(0, 1)
 	bar := lipgloss.NewStyle().Foreground(userBubbleBar).Render("┃")
-	// lipgloss 的 Width 只做按词边界的软折行:超长无空格单行(日志/JSON/minified 代码)
-	// 找不到断词点就不硬断,会横向溢出 chat 区。再套一层 ansi.Wrap 做硬折行兜底,
-	// 任何超宽行都被强制断到内容区宽内(box 带左右 Padding(0,1) 各 1 列,内容宽 = boxW-2),
-	// 与模型回复走 glamour 的一致,避免粘贴长文本后错乱。
-	innerW := boxW - 2
-	if innerW < 1 {
-		innerW = 1
-	}
-	rendered := ansi.Wrap(box.Render(text), innerW, "")
-	lines := strings.Split(rendered, "\n")
+	// lipgloss 的 Width 已经会硬折行:超长无空格单行(日志/JSON/minified 代码)找不到断词点
+	// 也会强制断到 boxW 内、并把每行补白到 boxW,不会横向溢出 chat 区。因此这里直接按 \n 切行
+	// 即可。切勿再套一层 ansi.Wrap ——那是对"已折行 + 已补白"的内容二次折行,会把行尾补白
+	// 顶到新行、生成交替空行(双倍行距)并打散补白,反而把气泡显示搞乱(见 user_bubble_test)。
+	lines := strings.Split(box.Render(text), "\n")
 	for i, ln := range lines {
 		lines[i] = bar + ln
 	}

--- a/tui/user_bubble_test.go
+++ b/tui/user_bubble_test.go
@@ -8,27 +8,31 @@ import (
 )
 
 // TestRenderUserBubbleNoOverflow 验证用户消息里的超长无空格单行(日志/JSON/minified
-// 代码)会被硬折行到 boxW 以内,不会横向溢出 chat 区。这是粘贴长文本的回归点。
+// 代码)会被硬折行、且每行都补白到统一宽度铺满 chat 区。这里同时钉死两件事:
+//   - 不横向溢出:任何行显示宽度都不超过 viewportW(= 色条 1 列 + boxW)。
+//   - 不双倍行距:lipgloss 的 Width 已经硬折行 + 补白,绝不能再套 ansi.Wrap 二次折行 ——
+//     那会把行尾补白顶到新行、生成交替空行并打散补白。故此处要求每行都恰好铺满 viewportW、
+//     且每行都含实际内容(无空的 "┃ " 行)。任一条不满足即说明二次折行回归复现。
 func TestRenderUserBubbleNoOverflow(t *testing.T) {
 	const viewportW = 40
 	longNoSpace := strings.Repeat("x", 200) // 200 字符无空格,远超 boxW
 	out := renderUserBubble(longNoSpace, viewportW)
 
-	// 去掉 ANSI 后逐行检查显示宽度 <= boxW(boxW = viewportW-1)
-	boxW := viewportW - 1
-	maxW := 0
-	for _, line := range strings.Split(out, "\n") {
+	lines := strings.Split(out, "\n")
+	if len(lines) == 0 {
+		t.Fatal("empty output")
+	}
+	for i, line := range lines {
 		plain := ansi.Strip(line)
 		w := ansi.StringWidth(plain)
-		if w > maxW {
-			maxW = w
+		// 每行都应铺满 viewportW:不足=补白被打散(二次折行回归),超过=横向溢出。
+		if w != viewportW {
+			t.Fatalf("line %d width %d != viewportW %d (overflow or broken padding): %q", i, w, viewportW, plain)
 		}
-	}
-	if maxW > boxW {
-		t.Fatalf("line display width %d exceeds boxW %d (overflow)", maxW, boxW)
-	}
-	if maxW == 0 {
-		t.Fatal("empty output")
+		// 去掉色条与补白后必须还有实际内容:出现空行=二次折行插入的交替空行。
+		if strings.Trim(plain, "┃ ") == "" {
+			t.Fatalf("line %d is a blank/padding-only row (double-wrap regression): %q", i, plain)
+		}
 	}
 }
 


### PR DESCRIPTION
renderUserBubble 里 lipgloss 的 Width 本就会硬折行超长无空格单行、并把每行 补白到 boxW,不会溢出 chat 区。#186 额外套的一层 ansi.Wrap 是对「已折行 + 已 补白」的内容二次折行:行尾补白被顶到新行 → 生成交替空行(双倍行距)、补白被
打散、右边参差。实测 200 个 x 在 viewportW=40 下,原来 6 行干净铺满,二次折行 后变 11 行含 5 个空「┃ 」行。

改回直接按 \n 切 box.Render 的输出,删掉不再用到的 x/ansi import。

同时补强 TestRenderUserBubbleNoOverflow:从「只查最大宽度 <= boxW」改为要求 每行都恰好铺满 viewportW 且含实际内容 —— 这样二次折行产生的空行/参差会被直接
测出(已验证:此断言在旧 ansi.Wrap 版本下 FAIL、在本修复下 PASS)。