### PR TITLE
✨ feat(tui): 输入区全选态下单击即取消高亮(#188)

### DIFF
--- a/tui/input_select_mouse_test.go
+++ b/tui/input_select_mouse_test.go
@@ -1,0 +1,57 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestInputClickCancelsSelectAll 钉死 #188 的修复:输入区"拖拽全选"高亮后,
+// 在输入区里单击一下(无拖动)即取消高亮 —— 此前只能靠键盘(方向键/Esc…)解除,
+// 鼠标用户最自然的"点一下取消"没接上。
+func TestInputClickCancelsSelectAll(t *testing.T) {
+	m := initModel()
+	// 建立视口/输入框尺寸,使鼠标命中判定与 refreshViewport 正常工作。
+	wm, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
+	m = wm.(model)
+	m.input.SetValue("hello world example text") // 非空才会触发全选
+
+	leftW, vpH := m.layout()
+	if vpH >= m.height {
+		t.Fatalf("前置失败:vpH(%d) 不小于 height(%d),无输入区可点", vpH, m.height)
+	}
+	px, py := 2, vpH // 输入区内一点:Y ∈ [vpH, height),X ∈ [0, leftW)
+	if px >= leftW {
+		t.Fatalf("前置失败:px(%d) 不在内容列 [0,%d)", px, leftW)
+	}
+	dragX := px + inputDragThreshold + 1 // 横移超阈值 → 判定为真拖动
+	if dragX >= leftW {
+		t.Fatalf("前置失败:dragX(%d) 超出内容列 [0,%d)", dragX, leftW)
+	}
+
+	// 1) 按下 → 真拖动 → 松手:应进入全选态,且松手保留高亮(拖拽复制全文)。
+	mm, _ := m.Update(tea.MouseClickMsg{X: px, Y: py, Button: tea.MouseLeft})
+	m = mm.(model)
+	mm, _ = m.Update(tea.MouseMotionMsg{X: dragX, Y: py, Button: tea.MouseLeft})
+	m = mm.(model)
+	if !m.inputAllSelected {
+		t.Fatalf("真拖动后应进入全选态")
+	}
+	mm, _ = m.Update(tea.MouseReleaseMsg{X: dragX, Y: py, Button: tea.MouseLeft})
+	m = mm.(model)
+	if !m.inputAllSelected {
+		t.Fatalf("拖拽松手应保留全选高亮(供再次操作 / 复制全文)")
+	}
+
+	// 2) 全选态下在输入区单击一下(按下即取消,松手无拖动)→ 高亮清除。
+	mm, _ = m.Update(tea.MouseClickMsg{X: px, Y: py, Button: tea.MouseLeft})
+	m = mm.(model)
+	if m.inputAllSelected {
+		t.Fatalf("全选态下在输入区按下应立即取消高亮(#188 点一下取消)")
+	}
+	mm, _ = m.Update(tea.MouseReleaseMsg{X: px, Y: py, Button: tea.MouseLeft})
+	m = mm.(model)
+	if m.inputAllSelected {
+		t.Fatalf("单击松手后不应再是全选态")
+	}
+}

--- a/tui/model.go
+++ b/tui/model.go
@@ -1459,6 +1459,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if inInput {
 			// 单击进入输入区:清 chat 选区 + 记下拖拽起点(双击全选已移除;全选只走真拖动)。
 			// 后续 MouseMotion 要移动超过阈值才判定为拖拽全选,避免双击抖动误触。
+			// 若此刻已处于"拖拽全选"高亮态:本次按下即取消它(#188 —— 鼠标用户最自然的
+			// "点一下取消"此前没接上,只能靠键盘解除)。清掉后若接着是真拖动,MouseMotion 会
+			// 重新点亮;若只是单击松手,就实现了点一下取消(release 见 inputAllSelected==false)。
+			if m.inputAllSelected {
+				m.inputAllSelected = false
+			}
 			m.inputDragging = true
 			m.inputDragStartX, m.inputDragStartY = msg.X, msg.Y
 			if m.selecting {


### PR DESCRIPTION
输入区"拖拽全选"是有意设计:textarea 不暴露选区 API,做不到 chat 区那种
子区间拖选,故拖动整段选中 + 复制全部。

修复:MouseClick 命中输入区时,若已处于全选态就先清掉高亮。之后若是真拖动,
MouseMotion 会重新点亮;若只是单击松手,就实现了"点一下取消"。既有的拖拽
复制全文行为不受影响。