### PR TITLE
✨ feat(tui): 输入区支持鼠标拖拽选择片段并复制(#188)

### DIFF
--- a/tui/input_select_mouse_test.go
+++ b/tui/input_select_mouse_test.go
@@ -1,57 +1,89 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
 )
 
-// TestInputClickCancelsSelectAll 钉死 #188 的修复:输入区"拖拽全选"高亮后,
-// 在输入区里单击一下(无拖动)即取消高亮 —— 此前只能靠键盘(方向键/Esc…)解除,
-// 鼠标用户最自然的"点一下取消"没接上。
-func TestInputClickCancelsSelectAll(t *testing.T) {
+// mouseInputAt 返回输入框内一个屏幕坐标:X = gutter + col,Y = textarea 文本首行。
+func (m model) mouseInputAt(col int) (x, y int) {
+	return inputGutterWidth + col, m.inputTextTopY()
+}
+
+// TestInputDragSelectsFragment 验证 #188 的部分选择:输入区拖拽选中一段 → 复制该片段;
+// 拖拽松手后保留高亮;随后单击一下(无拖动)→ 取消高亮(点一下取消)。
+func TestInputDragSelectsFragment(t *testing.T) {
 	m := initModel()
-	// 建立视口/输入框尺寸,使鼠标命中判定与 refreshViewport 正常工作。
 	wm, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
 	m = wm.(model)
-	m.input.SetValue("hello world example text") // 非空才会触发全选
+	m.input.SetValue("hello world")
 
-	leftW, vpH := m.layout()
-	if vpH >= m.height {
-		t.Fatalf("前置失败:vpH(%d) 不小于 height(%d),无输入区可点", vpH, m.height)
-	}
-	px, py := 2, vpH // 输入区内一点:Y ∈ [vpH, height),X ∈ [0, leftW)
-	if px >= leftW {
-		t.Fatalf("前置失败:px(%d) 不在内容列 [0,%d)", px, leftW)
-	}
-	dragX := px + inputDragThreshold + 1 // 横移超阈值 → 判定为真拖动
-	if dragX >= leftW {
-		t.Fatalf("前置失败:dragX(%d) 超出内容列 [0,%d)", dragX, leftW)
-	}
+	ax, ay := m.mouseInputAt(0) // 锚点:第 0 列
+	ex, ey := m.mouseInputAt(5) // 拖到第 5 列("hello" 之后)
 
-	// 1) 按下 → 真拖动 → 松手:应进入全选态,且松手保留高亮(拖拽复制全文)。
-	mm, _ := m.Update(tea.MouseClickMsg{X: px, Y: py, Button: tea.MouseLeft})
+	// 按下 → 拖动到不同列 → 应进入选区态
+	mm, _ := m.Update(tea.MouseClickMsg{X: ax, Y: ay, Button: tea.MouseLeft})
 	m = mm.(model)
-	mm, _ = m.Update(tea.MouseMotionMsg{X: dragX, Y: py, Button: tea.MouseLeft})
-	m = mm.(model)
-	if !m.inputAllSelected {
-		t.Fatalf("真拖动后应进入全选态")
+	if m.inputSelecting {
+		t.Fatalf("刚按下(未拖动)不应有选区")
 	}
-	mm, _ = m.Update(tea.MouseReleaseMsg{X: dragX, Y: py, Button: tea.MouseLeft})
+	mm, _ = m.Update(tea.MouseMotionMsg{X: ex, Y: ey, Button: tea.MouseLeft})
 	m = mm.(model)
-	if !m.inputAllSelected {
-		t.Fatalf("拖拽松手应保留全选高亮(供再次操作 / 复制全文)")
+	if !m.inputSelecting {
+		t.Fatalf("拖到不同列后应进入选区态")
+	}
+	if got := m.inputSelectionText(); !strings.Contains(got, "hello") || strings.Contains(got, "world") {
+		t.Fatalf("选区文本应为片段 \"hello\",实得 %q", got)
 	}
 
-	// 2) 全选态下在输入区单击一下(按下即取消,松手无拖动)→ 高亮清除。
-	mm, _ = m.Update(tea.MouseClickMsg{X: px, Y: py, Button: tea.MouseLeft})
+	// 松手:保留高亮(供再操作 / 复制已发出)
+	mm, _ = m.Update(tea.MouseReleaseMsg{X: ex, Y: ey, Button: tea.MouseLeft})
 	m = mm.(model)
-	if m.inputAllSelected {
-		t.Fatalf("全选态下在输入区按下应立即取消高亮(#188 点一下取消)")
+	if !m.inputSelecting {
+		t.Fatalf("拖拽松手后应保留选区高亮")
 	}
-	mm, _ = m.Update(tea.MouseReleaseMsg{X: px, Y: py, Button: tea.MouseLeft})
+
+	// 单击一下(无拖动)→ 点一下取消
+	cx, cy := m.mouseInputAt(2)
+	mm, _ = m.Update(tea.MouseClickMsg{X: cx, Y: cy, Button: tea.MouseLeft})
 	m = mm.(model)
-	if m.inputAllSelected {
-		t.Fatalf("单击松手后不应再是全选态")
+	if m.inputSelecting {
+		t.Fatalf("单击按下应立即取消选区高亮(点一下取消)")
+	}
+	mm, _ = m.Update(tea.MouseReleaseMsg{X: cx, Y: cy, Button: tea.MouseLeft})
+	m = mm.(model)
+	if m.inputSelecting {
+		t.Fatalf("单击松手后不应再有选区")
+	}
+}
+
+// TestInputSelectionClearedByKey 验证选区是"复制标记":任何按键都取消它、再走正常处理
+// (不删 value)。
+func TestInputSelectionClearedByKey(t *testing.T) {
+	m := initModel()
+	wm, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
+	m = wm.(model)
+	m.input.SetValue("abcdef")
+
+	ax, ay := m.mouseInputAt(0)
+	ex, ey := m.mouseInputAt(3)
+	mm, _ := m.Update(tea.MouseClickMsg{X: ax, Y: ay, Button: tea.MouseLeft})
+	m = mm.(model)
+	mm, _ = m.Update(tea.MouseMotionMsg{X: ex, Y: ey, Button: tea.MouseLeft})
+	m = mm.(model)
+	if !m.inputSelecting {
+		t.Fatalf("前置失败:未进入选区态")
+	}
+
+	// 按方向键:取消选区,但 value 不动(不再是旧的"全选态清空"语义)
+	mm, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyRight}))
+	m = mm.(model)
+	if m.inputSelecting {
+		t.Fatalf("按键后应取消选区标记")
+	}
+	if m.input.Value() != "abcdef" {
+		t.Fatalf("取消选区不应改动 value,实得 %q", m.input.Value())
 	}
 }

--- a/tui/model.go
+++ b/tui/model.go
@@ -33,10 +33,6 @@ import (
 
 var imagePlaceholderRe = regexp.MustCompile(`\[Image #(\d+)\]`)
 
-// inputDragThreshold 是触发"输入框拖拽全选"所需的最小横向移动格数。
-// 双击/点击时常有 1~2 格抖动,设 3 可把这种抖动挡在外面,只有真拖动才全选。
-const inputDragThreshold = 3
-
 // 长文本粘贴阈值:超过 800 字符,或超过一定行数(按视口高度动态)的文本,不直接塞进输入框,
 // 而是存全文、在输入框放占位符 [Pasted text #N +X lines]。
 // 与 free-code 一致:字符阈值用 PASTE_THRESHOLD=800;行数阈值 = min(height-10, pasteLineThresholdCap),
@@ -220,10 +216,13 @@ type model struct {
 	selAnchor cellPos
 	selEnd    cellPos
 
-	// 输入框全选态(鼠标拖拽全选触发)。true 时输入框 value 整段反色显示,
-	// 下一次按键消费"全选"语义:输入字符 / 删除键 → 清空 value 后再 process;
-	// Esc / 方向键 → 仅取消选择,不动 value。
-	inputAllSelected bool
+	// 输入框选区态(鼠标拖拽触发的"部分选择",用于复制片段)。true 时按
+	// inputSelAnchor/inputSelEnd 在输入框可见行上画反色。坐标口径与 chat 选区一致
+	// (cellPos.col=显示列,line=textarea 可见行 taLines 的行号),复用 selection.go 的
+	// applySelectionHighlight / extractSelectionText。它只是"标记待复制",不参与编辑:
+	// 任何按键都会取消它、再走正常处理(不删 value)。
+	inputSelecting              bool
+	inputSelAnchor, inputSelEnd cellPos
 
 	// app 侧光标 blink 状态。textarea 用真实终端光标(SetVirtualCursor(false)),
 	// 而部分终端(VS Code 集成终端)不响应 DECSCUSR 的 blink 位,只好由 app 自己切
@@ -247,10 +246,9 @@ type model struct {
 	showReasoningModal bool
 	reasoningModalRow  int
 
-	// inputDragging 表示左键在输入框区域按下后还没松开,用来实现"输入框拖拽全选":
-	// 拖动中 → inputAllSelected=true 高亮整段;松手 → 复制输入框内容到剪贴板。
-	// inputDragStartX/Y 记按下时坐标:只有移动超过阈值(见 inputDragThreshold)才算"真拖动",
-	// 否则双击/点击时的微小抖动会被误判成拖拽 → 误全选。
+	// inputDragging 表示左键在输入框区域按下后还没松开,用来实现"输入框拖拽选择片段":
+	// 按下记锚点,拖动中更新 inputSelEnd + inputSelecting=true 画高亮,松手复制选中片段。
+	// inputDragStartX/Y 记按下时屏幕坐标(仅用于是否移动过的判定,真正选区走 cellPos)。
 	inputDragging                    bool
 	inputDragStartX, inputDragStartY int
 
@@ -1415,6 +1413,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.input.SetWidth(leftW - inputGutterWidth)
 		// 窗口尺寸变了 → wrap 重算 → 老 line 号失效,必须清选区
 		m.selecting = false
+			m.inputSelecting = false
 		m.refreshViewport()
 
 	case tea.MouseWheelMsg:
@@ -1457,13 +1456,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		inInput := msg.Y >= vpH && msg.Y < m.height && msg.X >= 0 && msg.X < leftW
 
 		if inInput {
-			// 单击进入输入区:清 chat 选区 + 记下拖拽起点(双击全选已移除;全选只走真拖动)。
-			// 后续 MouseMotion 要移动超过阈值才判定为拖拽全选,避免双击抖动误触。
-			// 若此刻已处于"拖拽全选"高亮态:本次按下即取消它(#188 —— 鼠标用户最自然的
-			// "点一下取消"此前没接上,只能靠键盘解除)。清掉后若接着是真拖动,MouseMotion 会
-			// 重新点亮;若只是单击松手,就实现了点一下取消(release 见 inputAllSelected==false)。
-			if m.inputAllSelected {
-				m.inputAllSelected = false
+			// 按下进入输入区:清 chat 选区 + 记拖拽锚点,准备"拖拽选择片段"。
+			// 同时把上一次的输入选区清掉:若接着是真拖动,MouseMotion 会重新点亮;
+			// 若只是单击松手,就等价于"点一下取消"(#188)。
+			m.inputSelecting = false
+			if a, ok := m.inputCellAt(msg.X, msg.Y); ok {
+				m.inputSelAnchor = a
+				m.inputSelEnd = a
 			}
 			m.inputDragging = true
 			m.inputDragStartX, m.inputDragStartY = msg.X, msg.Y
@@ -1506,17 +1505,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// 输入框拖拽全选:必须是"真拖动"——横向移过 inputDragThreshold 格,或换了行——才整段选高亮。
-		// 这样双击/点击时一两格的抖动不会被误判成拖拽。输入框内容通常一行/几行,够阈值就直接整段选。
+		// 输入框拖拽选择片段:把光标映射成输入可见行的 cellPos,只要落到与锚点不同的
+		// 单元格就开始/更新选区高亮(同格内的抖动不触发,避免单击误选)。
 		if m.inputDragging {
-			dx := msg.X - m.inputDragStartX
-			if dx < 0 {
-				dx = -dx
-			}
-			realDrag := dx >= inputDragThreshold || msg.Y != m.inputDragStartY
-			if realDrag && m.input.Value() != "" && !m.inputAllSelected {
-				m.inputAllSelected = true
-				m.refreshViewport()
+			if e, ok := m.inputCellAt(msg.X, msg.Y); ok && m.input.Value() != "" {
+				if e.col != m.inputSelAnchor.col || e.line != m.inputSelAnchor.line {
+					m.inputSelEnd = e
+					m.inputSelecting = true
+				} else {
+					// 拖回锚点同格 → 取消选区(选区收拢为空)。
+					m.inputSelEnd = e
+					m.inputSelecting = false
+				}
 			}
 			return m, nil
 		}
@@ -1565,12 +1565,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.scrollbarDragging = false
 			return m, nil
 		}
-		// 输入框拖拽全选松手:复制整段输入框内容(不弹"已复制"提示)。
+		// 输入框拖拽松手:若真的选了一段(inputSelecting),复制选中片段并弹"已复制"提示
+		// (与 chat 区一致)。纯单击(无选区)→ 什么都不做 = 点一下取消。
 		if m.inputDragging {
 			m.inputDragging = false
-			if m.inputAllSelected {
-				if text := m.input.Value(); text != "" {
-					return m, clipboardWriteCmd(text)
+			if m.inputSelecting {
+				if text := m.inputSelectionText(); text != "" {
+					m.copyHint = T("copy.done")
+					m.copyHintX = msg.X
+					m.copyHintY = msg.Y
+					return m, tea.Batch(clipboardWriteCmd(text), clearCopyHintCmd())
 				}
 			}
 			return m, nil
@@ -1624,11 +1628,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// 空 paste 内容 = 终端有 paste 事件但 PTY 里没文本 → 大概率剪贴板只有图片,主动读 PNG。
 		// 非空 paste 内容 = 普通文本粘贴,放掉让 textinput 自己接(它有 PasteMsg 处理)。
 		if msg.Content == "" {
-			if m.inputAllSelected {
-				m.input.SetValue("")
-				m.attachedImagePaths = nil
-				m.inputAllSelected = false
-			}
+			m.inputSelecting = false // 选区只是复制标记,粘贴图片不清空 value
 			if data, err := readClipboardImage(); err == nil {
 				path, ferr := saveAttachedImage(data, len(m.attachedImagePaths)+1)
 				if ferr != nil {
@@ -2279,38 +2279,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		// 拖拽全选态预处理:整段反色高亮后,任何其他按键都要先消费"全选"语义。
-		// 放在外层 switch 之前,确保所有后续 case 都看不到带 selected 的状态。
-		if m.inputAllSelected {
-			switch msg.String() {
-			case "esc":
-				m.inputAllSelected = false
+		// 输入框选区(复制标记)预处理:它不参与编辑,任何按键都先取消它、再走正常处理。
+		// Esc 只取消不做别的;其余键取消后继续(打字/删除/移动光标照常,不再"清空 value")。
+		if m.inputSelecting {
+			m.inputSelecting = false
+			if msg.String() == "esc" {
 				return m, nil
-			case "ctrl+c":
-				// 保留原"非流式时退出"语义,不被 selected 改变
-			case "left", "right", "home", "end",
-				"pgup", "pgdown", "pageup", "pagedown":
-				// 方向 / 翻页 → 仅取消选择,光标移动交给后续 textinput.Update
-				m.inputAllSelected = false
-			case "up", "down":
-				// 全选态下的 ↑↓ 仅取消选择并交给 textarea 处理光标移动，
-				// 不进入历史翻阅（避免取消选择后意外跳历史）。
-				m.inputAllSelected = false
-				return m, nil
-			case "backspace", "delete", "ctrl+w", "ctrl+u":
-				m.input.SetValue("")
-				m.attachedImagePaths = nil
-				m.inputAllSelected = false
-				return m, nil
-			case "enter":
-				// 全选状态按 Enter:按原 enter 流程走(发送当前 value),同时清除选择标记
-				m.inputAllSelected = false
-				// 不 return,继续走外层 enter case
-			default:
-				// 可打印字符或其他键:先清空 value,再让 textinput 处理这次按键(就把新字符填入空 value)
-				m.input.SetValue("")
-				m.attachedImagePaths = nil
-				m.inputAllSelected = false
 			}
 		}
 		switch msg.String() {
@@ -2320,7 +2294,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if strings.TrimSpace(m.input.Value()) != "" || len(m.attachedImagePaths) > 0 {
 				m.input.SetValue("")
 				m.attachedImagePaths = nil
-				m.inputAllSelected = false
+				m.inputSelecting = false
 				m.lastCtrlCAt = time.Time{}
 				m.input.SetHeight(inputTextRows) // 多行清空后把视口/高度复位
 				return m, nil

--- a/tui/paste_check_test.go
+++ b/tui/paste_check_test.go
@@ -15,6 +15,12 @@ func initModel() model {
 	m.height = 30 // 常态终端高度,使 pasteLineCap = min(30-10,2) = 2,与 free-code 一致
 	m.width = 80
 	m.input = textarea.New()
+	// 对齐生产输入框配置(见 initialModel):关行号 / 空 Prompt / 固定行高 / 真实光标,
+	// 否则 m.input.View() 会带默认行号 gutter,鼠标选区坐标就对不上。
+	m.input.ShowLineNumbers = false
+	m.input.Prompt = ""
+	m.input.SetHeight(inputTextRows)
+	m.input.SetVirtualCursor(false)
 	m.input.Focus()
 	m.chatContent = newChatLog(1 << 20)
 	m.chatViewport = viewport.New()

--- a/tui/selection.go
+++ b/tui/selection.go
@@ -131,6 +131,78 @@ func extractSelectionText(wrapped string, a, b cellPos, width int) string {
 	return strings.Join(out, "\n")
 }
 
+// inputTextTopY 返回输入框 textarea 文本第一行在屏幕上的 Y(与 view.go 的排布口径一致):
+// body 高度 + 排队区行数 + 顶部留白。用于把鼠标 Y 映射成 textarea 可见行号。
+func (m model) inputTextTopY() int {
+	leftW, _ := m.layout()
+	queuedH := len(m.queuedDisplayLines(leftW))
+	bodyH := m.height - inputAreaHeight - queuedH
+	if bodyH < 1 {
+		bodyH = 1
+	}
+	return bodyH + queuedH + inputTopPad
+}
+
+// inputCellAt 把屏幕坐标 (x,y) 映射成输入框可见内容里的 cellPos(col=显示列,
+// line=textarea 可见行 taLines 的行号)。坐标口径与 view.go 渲染一致:内容从
+// gutter 右边(inputGutterWidth 列)起、逐行对应 m.input.View() 的行。col 夹到该行
+// 实际文字宽度内(点到文字末尾之后即贴到行尾),line 夹到可见行范围内。
+func (m model) inputCellAt(x, y int) (cellPos, bool) {
+	leftW, _ := m.layout()
+	w := leftW - inputGutterWidth
+	if w < 1 {
+		return cellPos{}, false
+	}
+	taLines := strings.Split(m.input.View(), "\n")
+	if len(taLines) == 0 {
+		return cellPos{}, false
+	}
+	// textarea 固定高度会在文字下方补空行;把 line 夹到"最后一个有内容的可见行",
+	// 免得往空白区拖时把补白行也选进来。
+	lastContent := 0
+	for i, ln := range taLines {
+		if strings.TrimRight(ansi.Strip(ln), " ") != "" {
+			lastContent = i
+		}
+	}
+	line := y - m.inputTextTopY()
+	if line < 0 {
+		line = 0
+	}
+	if line > lastContent {
+		line = lastContent
+	}
+	col := x - inputGutterWidth
+	if col < 0 {
+		col = 0
+	}
+	// 夹到该可见行的实际文字宽度(去尾部补白):点到文字尾部之后就贴到文字末尾,
+	// 不把行尾补白算进选区。
+	lw := ansi.StringWidth(strings.TrimRight(ansi.Strip(taLines[line]), " "))
+	if col > lw {
+		col = lw
+	}
+	if col >= w {
+		col = w - 1
+	}
+	return cellPos{col: col, line: line}, true
+}
+
+// inputSelectionText 抠出输入框当前选区的纯文本(基于 m.input.View() 的可见行,
+// 复用 chat 的 extractSelectionText)。因此软换行/纵向滚动都天然正确 —— 选的、抠的
+// 都是屏幕上看得见的那几行。选区为空返回 ""。
+func (m model) inputSelectionText() string {
+	if !m.inputSelecting {
+		return ""
+	}
+	leftW, _ := m.layout()
+	w := leftW - inputGutterWidth
+	if w < 1 {
+		return ""
+	}
+	return extractSelectionText(m.input.View(), m.inputSelAnchor, m.inputSelEnd, w)
+}
+
 // copySelection 把当前选区文本写进剪贴板,并弹一个"已复制"临时提示。选区为空返回 nil。
 //
 // 本地优先用原生剪贴板(pbcopy/xclip/clip.exe),**不再叠加 OSC52**:

--- a/tui/view.go
+++ b/tui/view.go
@@ -215,18 +215,13 @@ func (m model) View() tea.View {
 
 	// 输入列内容:gutter + textarea 逐行拼接,首行 "❱ ";上接活动状态行/留白,中间夹排队区。
 	taView := m.input.View()
-	taLines := strings.Split(taView, "\n")
-	if m.inputAllSelected {
-		// 逐行 strip 成纯文本再套反色:textarea 输出里的内部 reset(\x1b[0m)会取消整段反色,
-		// 导致全选看不到高亮。只反色每行实际文字,空行 / 尾部空白不动。
-		for i, ln := range taLines {
-			plain := strings.TrimRight(ansi.Strip(ln), " ")
-			if plain == "" {
-				continue
-			}
-			taLines[i] = ansiReverseOn + plain + ansiReverseOff
-		}
+	if m.inputSelecting {
+		// 鼠标拖拽选中的片段:复用 chat 的流式选区高亮(反色),坐标 = inputSelAnchor/End,
+		// 宽度 = textarea 显示宽(leftW - gutter)。它内部会 strip 选中段的 ANSI 再套反色,
+		// 规避 textarea 输出里的内部 reset 取消高亮的问题。
+		taView = applySelectionHighlight(taView, m.inputSelAnchor, m.inputSelEnd, leftW-inputGutterWidth)
 	}
+	taLines := strings.Split(taView, "\n")
 	inputRows := make([]string, len(taLines))
 	for i, tl := range taLines {
 		gutter := strings.Repeat(" ", inputGutterWidth)


### PR DESCRIPTION
此前输入区拖拽只能"全选+复制全部"(#189),因 bubbles v2 textarea 不暴露选区 API。本版在 textarea 渲染输出之上自造流式选区,做到和 chat 区一致的"部分选择":