### PR TITLE
✨ feat(agent): 视觉模型对外部图片路径调 OCR 时改为内联识图(#194)

### DIFF
--- a/agent/image_render.go
+++ b/agent/image_render.go
@@ -251,6 +251,37 @@ func priorOCRResult(argsJSON string, convo []ChatMessage) (string, bool) {
 	return "", false
 }
 
+// imageFileExtRe 匹配图片文件扩展名(结尾)。
+var imageFileExtRe = regexp.MustCompile(`(?i)\.(?:png|jpe?g|gif|webp|bmp)$`)
+
+// ocrImageFilePath 解析 OCR 调用的 path 参数,若它指向一个"真实存在的本地图片文件",
+// 返回其绝对路径 + true;否则返回 "", false。
+//
+// 用途(issue #194):视觉模型对一张外部图片路径调 OCR 时,本地 OCR 精度不如模型多模态。
+// 命中即改为把该图内联进对话让模型直接看(见 llm.go case "OCR"),不跑本地 OCR。
+// 只认扩展名为常见图片格式、且 os.Stat 确认存在的普通文件 —— 不存在 / 目录一律不命中。
+func ocrImageFilePath(argsJSON string) (string, bool) {
+	var args struct {
+		Path string `json:"path"`
+	}
+	if json.Unmarshal([]byte(argsJSON), &args) != nil {
+		return "", false
+	}
+	p := strings.TrimSpace(args.Path)
+	if p == "" || !imageFileExtRe.MatchString(p) {
+		return "", false
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", false
+	}
+	info, err := os.Stat(abs)
+	if err != nil || info.IsDir() {
+		return "", false
+	}
+	return abs, true
+}
+
 // isImageInputUnsupported 判断错误是否是"该端点/模型不接受图片输入"(发了 base64 才会撞)。
 // 命中则上层把该模型降级为无视觉、改走 OCR 重发。匹配宽松些以兼容各家措辞。
 //   - MiMo: HTTP 404 "No endpoints found that support image input"

--- a/agent/llm.go
+++ b/agent/llm.go
@@ -745,6 +745,9 @@ func StartStream(
 			//   - UpdatePlanStatus   → 解析后产 TaskStatusMsg,UI 更新单项状态
 			//   - SwitchModel        → 改本轮 currentEntry / role,通过 ModelSwitchMsg 通知 UI
 			// 拦截后仍要给 LLM 一个 fake tool result,让 OpenAI 工具循环能正常推进。
+			// pendingImageInjects:本轮被 redirect 的 OCR(视觉模型 + 真实外部图)对应的图片路径,
+			// 在 tc 循环收尾处统一追加成带图 user 消息,让模型下一轮直接看图(见 case "OCR",issue #194)。
+			var pendingImageInjects []string
 			for _, tc := range toolCalls {
 				// review 模式:对 Write/Update/Bash 发起审核。
 				// Workflow(run) 无论何种模式都强制确认:它会执行模型生成的脚本(进而派子 agent)。
@@ -941,6 +944,16 @@ func StartStream(
 							Output:  "这张图之前已经 OCR 过了,结果是:\n" + prev + "\n\n请勿对同一张图重复 OCR。若仍需要图中信息,请直接询问用户图里写了什么,或让用户改用支持视觉的模型。",
 							Success: false,
 						}
+					} else if img, ok := ocrImageFilePath(tc.Function.Arguments); currentEntry.Vision && ok {
+						// 视觉模型对一张真实存在的外部图片调 OCR:本地 OCR 精度不如模型多模态(issue #194)。
+						// 不跑本地 OCR,改为把该图内联进对话 —— 下方在 tc 循环收尾处追加一条带该图的 user 消息
+						// (ImagePaths,交给 renderConvoImages 下一轮按能力渲染成 base64),让模型直接看图作答。
+						// 追加(非改历史)不破前缀缓存;第二次对同一图 OCR 会被上面的 ocrTargetsInlinedImage 命中,不重复注入。
+						result = tools.ToolResult{
+							Output:  "当前模型支持视觉,已把该图片内联到对话,请直接查看图片作答,不要再调用 OCR。",
+							Success: true,
+						}
+						pendingImageInjects = append(pendingImageInjects, img)
 					} else {
 						result = executeTool(tc, mode, &lastFile)
 					}
@@ -982,6 +995,16 @@ func StartStream(
 					// 本轮合计上限:单条已被 clampToolOutput 限到 96KB,这里再按「本轮所有工具结果合计」收口,
 					// 防止一轮并发多条把上下文顶爆(issue #135)。只截入历史的内容,UI(上方 ToolCallResultMsg)仍展示完整结果。
 					Content: clampTurnToolOutput(tc.Function.Name, result.Output, &turnToolBytes),
+				})
+			}
+			// 视觉模型下被 redirect 的 OCR：把对应图片作为独立 user 消息追加进对话（带 ImagePaths，
+			// renderConvoImages 下一轮按当轮模型能力渲染成 base64 / 路径+OCR，切模型也安全）。
+			// 追加在所有 tool 结果之后，让模型下一轮直接看到内联的图（issue #194）。
+			for _, p := range pendingImageInjects {
+				convo = append(convo, ChatMessage{
+					Role:       "user",
+					Content:    "[Image #1]（上一步你请求 OCR 的图片，当前模型支持视觉，已内联在此，请直接识别，勿再调用 OCR。）",
+					ImagePaths: []string{p},
 				})
 			}
 			ch <- HistoryUpdateMsg{History: convo}

--- a/agent/ocr_redirect_test.go
+++ b/agent/ocr_redirect_test.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOcrImageFilePath 验证 #194 的判定:OCR 的 path 指向真实本地图片文件才命中,
+// 不存在 / 目录 / 非图片扩展名 / 坏 JSON 一律不命中。
+func TestOcrImageFilePath(t *testing.T) {
+	dir := t.TempDir()
+	img := filepath.Join(dir, "pic.png")
+	if err := os.WriteFile(img, []byte("\x89PNG"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	txt := filepath.Join(dir, "note.txt")
+	if err := os.WriteFile(txt, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	imgDir := filepath.Join(dir, "d.png")
+	if err := os.Mkdir(imgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	args := func(p string) string {
+		b, _ := json.Marshal(map[string]string{"path": p})
+		return string(b)
+	}
+
+	cases := []struct {
+		name    string
+		argJSON string
+		wantOK  bool
+		wantAbs string
+	}{
+		{"真实图片", args(img), true, img},
+		{"不存在", args(filepath.Join(dir, "nope.png")), false, ""},
+		{"非图片扩展名", args(txt), false, ""},
+		{"图片扩展名的目录", args(imgDir), false, ""},
+		{"空 path", args(""), false, ""},
+		{"坏 JSON", "{not json", false, ""},
+	}
+	for _, c := range cases {
+		got, ok := ocrImageFilePath(c.argJSON)
+		if ok != c.wantOK {
+			t.Errorf("%s: ok=%v want %v", c.name, ok, c.wantOK)
+			continue
+		}
+		if ok && got != c.wantAbs {
+			t.Errorf("%s: abs=%q want %q", c.name, got, c.wantAbs)
+		}
+	}
+}


### PR DESCRIPTION
用户在文本里直接给图片路径(而非粘贴)时,裸路径是纯文本、模型看不到那张图,
只能退回本地 OCR —— 而本地 OCR 对复杂图不如模型多模态准(reporter 诉求)。

改在 OCR 工具调用这一刻分流(agent/llm.go case "OCR"):视觉模型 + path 指向一张 真实存在的本地图片文件(ocrImageFilePath:图片扩展名 + os.Stat 普通文件)→ 不跑 本地 OCR,回一条"已内联,请直接看图"的 tool 结果,并在 tc 循环收尾追加一条带该图
(ImagePaths + [Image #N])的 user 消息;renderConvoImages 每轮重渲,下一轮即把图 内联成 base64,模型直接看图作答。
