### PR TITLE
🐛 fix(windows): 剪贴板操作锁 OS 线程,修粘贴图片后全局复制粘贴失效(#195)

### DIFF
--- a/tui/clipboard_windows.go
+++ b/tui/clipboard_windows.go
@@ -10,6 +10,7 @@ import (
 	"image"
 	"image/color"
 	"image/png"
+	"runtime"
 	"syscall"
 	"unsafe"
 )
@@ -39,6 +40,14 @@ func readClipboardImage() ([]byte, error) {
 	if avail == 0 {
 		return nil, errNoClipboardImage
 	}
+
+	// Windows 剪贴板按 OS 线程归属:OpenClipboard 在哪个线程开,必须在同一线程 CloseClipboard
+	// 才能成功关闭。Go 的 goroutine 会在 syscall 间被调度到别的 OS 线程 —— 尤其本函数下面
+	// 还要跑 dibToPNG(PNG 编码,耗时+分配)期间剪贴板一直开着,极易迁线程 → defer CloseClipboard
+	// 落到另一线程 → 关闭失败 → 剪贴板被全局锁死(issue #195)。锁住当前线程,把 open→close 钉在一起。
+	// defer 后进先出:UnlockOSThread 在 CloseClipboard 之后执行,保证关闭时仍在同一线程。
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	var opened uintptr
 	// OpenClipboard 可能因为别人正在持有而短暂失败,重试几次。

--- a/tui/clipboard_write_windows.go
+++ b/tui/clipboard_write_windows.go
@@ -4,6 +4,7 @@ package tui
 
 import (
 	"errors"
+	"runtime"
 	"syscall"
 	"unsafe"
 )
@@ -31,6 +32,11 @@ func writeClipboardText(text string) error {
 	if err != nil {
 		return err // 文本里含 NUL 才会失败,选区文本不该有
 	}
+
+	// 锁住 OS 线程:Windows 剪贴板按线程归属,不锁则 OpenClipboard 与 defer CloseClipboard
+	// 可能落在不同线程 → 关闭失败、剪贴板被全局锁死(见 readClipboardImage / issue #195)。
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	// OpenClipboard 可能因别人持有而短暂失败,重试几次(同 readClipboardImage)。
 	var opened uintptr


### PR DESCRIPTION
Windows 剪贴板按 OS 线程归属:OpenClipboard 在哪个线程开,必须在同一线程
CloseClipboard 才能关。Go 的 goroutine 会在 syscall 间被调度到别的 OS 线程 —— readClipboardImage 尤甚:它 return dibToPNG(dib),PNG 编码(耗时+分配)期间 剪贴板还开着,极易迁线程 → defer CloseClipboard 落到另一线程 → 关闭失败 → 剪贴板被全局锁死,记事本/浏览器都不能复制粘贴(图片必现、文本很少,因文本
读写 syscall 少、几乎不迁线程)。

readClipboardImage / writeClipboardText 均在 OpenClipboard 前 runtime.LockOSThread()
+ defer UnlockOSThread(),把 open→close 钉在同一线程(defer 后进先出, UnlockOSThread 在 CloseClipboard 之后执行)。这是 Go 调 Win32 剪贴板的标准做法。