### PR TITLE
🔧 test(tools): extractID 挪到跨平台文件,修 Windows 测试构建

### DIFF
--- a/tools/bg_test.go
+++ b/tools/bg_test.go
@@ -127,16 +127,3 @@ func TestBackgroundUnknownID(t *testing.T) {
 		t.Fatal("空 id 应返回失败")
 	}
 }
-
-func extractID(t *testing.T, output string) string {
-	t.Helper()
-	_, rest, ok := strings.Cut(output, "id: ")
-	if !ok {
-		t.Fatalf("输出里找不到 id: %q", output)
-	}
-	end := strings.IndexAny(rest, ")\n ")
-	if end < 0 {
-		t.Fatalf("解析 id 失败: %q", output)
-	}
-	return rest[:end]
-}

--- a/tools/testhelpers_test.go
+++ b/tools/testhelpers_test.go
@@ -1,0 +1,23 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// extractID 从 RunCommand/startBackground 的输出里解析出后台句柄 id(形如 "id: bash_123)")。
+// 纯字符串解析、无平台依赖,放在不带 //go:build 约束的文件里 —— 这样 bg_test.go(!windows)
+// 和 command_test.go(跨平台、运行时按 GOOS 跳过)都能用,且不会在 Windows 上因它未定义而
+// 编译失败(issue #195 交叉编译时暴露)。
+func extractID(t *testing.T, output string) string {
+	t.Helper()
+	_, rest, ok := strings.Cut(output, "id: ")
+	if !ok {
+		t.Fatalf("输出里找不到 id: %q", output)
+	}
+	end := strings.IndexAny(rest, ")\n ")
+	if end < 0 {
+		t.Fatalf("解析 id 失败: %q", output)
+	}
+	return rest[:end]
+}


### PR DESCRIPTION
command_test.go 是跨平台的(RunCommand 测试运行时按 runtime.GOOS 跳过 Windows), 但它引用的 extractID 定义在 bg_test.go(//go:build !windows)里 —— Windows 下该 符号未定义,导致整个 tools 测试包在 Windows 上编译失败(交叉编译 #195 时暴露)。

extractID 是纯字符串解析、无平台依赖,挪到不带约束的 testhelpers_test.go, bg_test.go(!windows)与 command_test.go(跨平台)都能用。command_test.go 一字未改, 保留其原有的运行时 GOOS 跳过设计。GOOS=windows go vet ./tools/ 现通过。