### PR TITLE
Fix/truncate oversized tool args 

### DIFF
--- a/agent/llm.go
+++ b/agent/llm.go
@@ -236,6 +236,39 @@ type chatRequest struct {
 	ReasoningEffort string          `json:"reasoning_effort,omitempty"`
 }
 
+// maxToolArgBytes:单个工具调用的 arguments 上限。超过就截断(见 truncateToolArgs)。
+// 触发背景:模型曾把整页 ~27KB HTML 当 Write 参数内联发出,既触发 OpenRouter/Novita 的 400
+// (invalid_request_error),也会让本地 llama.cpp 在生成超大参数时 JSON 断尾报 500。
+// 16KB 是经验值:正常工具参数远小于此,只有"整篇文件内容内联"才会触顶。
+const maxToolArgBytes = 16 * 1024
+
+// truncateToolArgs 返回 convo 的副本,其中超长工具参数被替换为一个带 original_bytes 的
+// 合法 JSON 占位。这样发出去的请求仍是合法 JSON(不会因硬截断产生非法 tool_calls 被 API 再拒),
+// 同时把几十 KB 的内联内容(整页 HTML 等)从请求里拿掉,规避 Novita 400 与 llama.cpp 500。
+// 原始对话不被改动(走副本),且工具此前已用完整参数执行过、结果在后续 tool 消息里,截断历史无害。
+// 返回是否发生过截断。
+func truncateToolArgs(convo []ChatMessage) ([]ChatMessage, bool) {
+	truncated := false
+	out := make([]ChatMessage, len(convo))
+	copy(out, convo)
+	for i := range out {
+		if len(out[i].ToolCalls) == 0 {
+			continue
+		}
+		tcs := make([]ToolCall, len(out[i].ToolCalls))
+		copy(tcs, out[i].ToolCalls)
+		for j := range tcs {
+			if n := len(tcs[j].Function.Arguments); n > maxToolArgBytes {
+				tcs[j].Function.Arguments = fmt.Sprintf(
+					`{"_deepx_truncated":true,"original_bytes":%d}`, n)
+				truncated = true
+			}
+		}
+		out[i].ToolCalls = tcs
+	}
+	return out, truncated
+}
+
 // thinkingOption 是 DeepSeek 思考开关的请求体格式:`{"type": "enabled"}` 或 `{"type": "disabled"}`。
 // DeepSeek 默认 enabled,MiMo 默认 disabled。
 type thinkingOption struct {
@@ -332,6 +365,7 @@ type chatResponse struct {
 // CallOnce 发起一次非流式 chat completion 调用,直接返回 content 文本。
 // 不带 tools 参数,适用于摘要生成等一次性文本生成场景。
 func CallOnce(ctx context.Context, apiKey, baseURL, modelID string, convo []ChatMessage, maxTokens int) (string, error) {
+	convo, _ = truncateToolArgs(convo)
 	body, err := json.Marshal(chatRequest{
 		Model:     modelID,
 		MaxTokens: maxTokens,
@@ -374,6 +408,7 @@ func CallOnce(ctx context.Context, apiKey, baseURL, modelID string, convo []Chat
 // 用于缓存友好的压缩:摘要请求复刻会话的 [system][tools][history] 前缀,只在末尾追加压缩指令,
 // 从而命中已缓存的前缀(tools 必须和被缓存的那次逐字节一致才命中,故由调用方传入旧 specs)。
 func CallWithTools(ctx context.Context, apiKey, baseURL, modelID string, convo []ChatMessage, toolSpecs []tools.OpenAIToolSpec, maxTokens int) (string, error) {
+	convo, _ = truncateToolArgs(convo)
 	body, err := json.Marshal(chatRequest{
 		Model:     modelID,
 		MaxTokens: maxTokens,
@@ -1271,6 +1306,10 @@ func streamAttempt(
 	ch chan<- tea.Msg,
 ) (string, string, []ToolCall, string, *UsageInfo, error) {
 
+	// 发送前消毒:剔除孤儿 tool 消息 / 剥掉无响应的 tool_calls,避免 API 400(见 issue #94),
+	// 并自愈已被写进历史的坏配对(下次请求即恢复)。正常对话是 no-op。
+	truncatedConvo, _ := truncateToolArgs(convo)
+	sanitized := sanitizeToolPairs(truncatedConvo)
 	body, err := json.Marshal(chatRequest{
 		Model:     modelID,
 		MaxTokens: maxTokens,
@@ -1278,9 +1317,7 @@ func streamAttempt(
 		StreamOptions: &streamOptions{
 			IncludeUsage: true,
 		},
-		// 发送前消毒:剔除孤儿 tool 消息 / 剥掉无响应的 tool_calls,避免 API 400(见 issue #94),
-		// 并自愈已被写进历史的坏配对(下次请求即恢复)。正常对话是 no-op。
-		Messages: sanitizeToolPairs(convo),
+		Messages: sanitized,
 		Tools:    toolSpecs,
 		// thinking 和 reasoning_effort 是两个独立顶层字段。各自 omitempty,
 		// 用户设了就发、没设就不发,白名单内的值才透传(防 yaml 笔误)。

--- a/agent/truncate_test.go
+++ b/agent/truncate_test.go
@@ -1,0 +1,190 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// makeBigArgs 返回字节长度精确为 n 的合法 JSON 字符串(模拟被内联的大文件参数)。
+func makeBigArgs(n int) string {
+	// 用 {"x":"<pad>"} 形态,先算出固定开销,再补 pad 到精确 n 字节。
+	const prefix = `{"x":"`
+	const suffix = `"}`
+	pad := strings.Repeat("a", n-len(prefix)-len(suffix))
+	s := prefix + pad + suffix
+	if len(s) != n {
+		panic("makeBigArgs 长度计算错误")
+	}
+	return s
+}
+
+func TestTruncateNoOpWhenSmall(t *testing.T) {
+	// 所有参数都远小于阈值 → 不应截断,原 convo 不被改动,返回 truncated=false。
+	orig := []ChatMessage{
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", ToolCalls: []ToolCall{
+			{ID: "c1", Function: ToolCallFunc{Name: "Read", Arguments: `{"path":"a.txt"}`}},
+		}},
+		{Role: "tool", ToolCallID: "c1", Content: "ok"},
+	}
+	snapshot := append([]ChatMessage(nil), orig...)
+
+	out, truncated := truncateToolArgs(orig)
+	if truncated {
+		t.Fatal("小参数不应触发截断")
+	}
+	if len(out) != len(orig) {
+		t.Fatalf("消息条数应一致,got %d", len(out))
+	}
+	if out[1].ToolCalls[0].Function.Arguments != `{"path":"a.txt"}` {
+		t.Fatalf("小参数应原样保留,got %q", out[1].ToolCalls[0].Function.Arguments)
+	}
+	// 原始 convo 必须未被改动(走副本)。
+	if orig[1].ToolCalls[0].Function.Arguments != `{"path":"a.txt"}` {
+		t.Fatal("原始 convo 被意外改动")
+	}
+	if len(snapshot) != len(orig) {
+		t.Fatal("原始 convo 被意外改动(长度)")
+	}
+}
+
+func TestTruncateLargeArg(t *testing.T) {
+	// 单个超大参数 → 替换为占位 JSON,original_bytes 正确,原始 convo 不动。
+	big := makeBigArgs(maxToolArgBytes + 100)
+	orig := []ChatMessage{
+		{Role: "assistant", ToolCalls: []ToolCall{
+			{ID: "c1", Function: ToolCallFunc{Name: "Write", Arguments: big}},
+		}},
+	}
+	out, truncated := truncateToolArgs(orig)
+	if !truncated {
+		t.Fatal("超大参数应触发截断")
+	}
+	got := out[0].ToolCalls[0].Function.Arguments
+	if got == big {
+		t.Fatal("超大参数未被替换")
+	}
+	// 占位必须是合法 JSON,且 original_bytes 等于原字节数。
+	var ph map[string]any
+	if err := json.Unmarshal([]byte(got), &ph); err != nil {
+		t.Fatalf("占位不是合法 JSON: %v (%q)", err, got)
+	}
+	if ph["_deepx_truncated"] != true {
+		t.Fatalf("占位缺少 _deepx_truncated 标记: %v", ph)
+	}
+	if int(ph["original_bytes"].(float64)) != len(big) {
+		t.Fatalf("original_bytes 应为 %d, got %v", len(big), ph["original_bytes"])
+	}
+	// 原始 convo 不动。
+	if orig[0].ToolCalls[0].Function.Arguments != big {
+		t.Fatal("原始 convo 被意外改动")
+	}
+}
+
+func TestTruncateBoundary(t *testing.T) {
+	// 边界:恰好等于阈值不截断;阈值+1 截断。这是最容易出 off-by-one 的地方。
+	atThreshold := makeBigArgs(maxToolArgBytes)
+	overThreshold := makeBigArgs(maxToolArgBytes + 1)
+
+	in := []ChatMessage{
+		{Role: "assistant", ToolCalls: []ToolCall{
+			{ID: "a", Function: ToolCallFunc{Name: "Write", Arguments: atThreshold}},
+			{ID: "b", Function: ToolCallFunc{Name: "Write", Arguments: overThreshold}},
+		}},
+	}
+	out, truncated := truncateToolArgs(in)
+	if !truncated {
+		t.Fatal("超过阈值的参数应触发截断")
+	}
+	if out[0].ToolCalls[0].Function.Arguments != atThreshold {
+		t.Fatalf("恰好等于阈值不应被截断,got %q", out[0].ToolCalls[0].Function.Arguments)
+	}
+	if out[0].ToolCalls[1].Function.Arguments == overThreshold {
+		t.Fatal("超过阈值应被截断")
+	}
+}
+
+func TestTruncateMixedSizesSameMessage(t *testing.T) {
+	// 同一条 assistant 消息里多个 tool_calls,只有大的被截,小的保留。
+	small := `{"path":"a.txt"}`
+	big := makeBigArgs(maxToolArgBytes + 50)
+	in := []ChatMessage{
+		{Role: "assistant", ToolCalls: []ToolCall{
+			{ID: "s", Function: ToolCallFunc{Name: "Read", Arguments: small}},
+			{ID: "b", Function: ToolCallFunc{Name: "Write", Arguments: big}},
+		}},
+	}
+	out, truncated := truncateToolArgs(in)
+	if !truncated {
+		t.Fatal("应触发截断")
+	}
+	if out[0].ToolCalls[0].Function.Arguments != small {
+		t.Fatalf("小参数应保留,got %q", out[0].ToolCalls[0].Function.Arguments)
+	}
+	if out[0].ToolCalls[1].Function.Arguments == big {
+		t.Fatal("大参数应被截断")
+	}
+	// ID 必须保留,否则后续 sanitize 配对会失效。
+	if out[0].ToolCalls[1].ID != "b" {
+		t.Fatalf("截断后 tool_call ID 丢失: %q", out[0].ToolCalls[1].ID)
+	}
+}
+
+func TestTruncateOnlyTargetsOversizedMessages(t *testing.T) {
+	// 多条消息,只有含超大参数的那条被改;其余原样。
+	big := makeBigArgs(maxToolArgBytes + 10)
+	in := []ChatMessage{
+		{Role: "user", Content: "read a.html"},
+		{Role: "assistant", ToolCalls: []ToolCall{
+			{ID: "c1", Function: ToolCallFunc{Name: "Read", Arguments: `{"path":"a.html"}`}},
+		}},
+		{Role: "tool", ToolCallID: "c1", Content: "file content"},
+		{Role: "assistant", ToolCalls: []ToolCall{
+			{ID: "c2", Function: ToolCallFunc{Name: "Write", Arguments: big}},
+		}},
+	}
+	out, truncated := truncateToolArgs(in)
+	if !truncated {
+		t.Fatal("应触发截断")
+	}
+	if len(out) != 4 {
+		t.Fatalf("消息条数应不变,got %d", len(out))
+	}
+	if out[1].ToolCalls[0].Function.Arguments != `{"path":"a.html"}` {
+		t.Fatal("无超大参数的消息不应被改")
+	}
+	if out[3].ToolCalls[0].Function.Arguments == big {
+		t.Fatal("含超大参数的消息应被截")
+	}
+}
+
+func TestTruncateSurvivesSanitize(t *testing.T) {
+	// 关键集成点:截断后仍要能通过 sanitizeToolPairs 配对(截断只改 Arguments,不动 ID)。
+	// 否则 streamAttempt 里 truncate→sanitize 的顺序会让被截的 tool_call 因失配被剥掉。
+	big := makeBigArgs(maxToolArgBytes + 200)
+	in := []ChatMessage{
+		{Role: "user", Content: "copy a.html to b.html"},
+		{Role: "assistant", ToolCalls: []ToolCall{
+			{ID: "c1", Function: ToolCallFunc{Name: "Write", Arguments: big}},
+		}},
+		{Role: "tool", ToolCallID: "c1", Content: "written"},
+	}
+	truncated, _ := truncateToolArgs(in)
+	sanitized := sanitizeToolPairs(truncated)
+
+	// 截断后的 assistant 仍应保留其 tool_call(ID 配对成功),tool 响应也保留。
+	if len(sanitized) != 3 {
+		t.Fatalf("截断+消毒后配对应完整,got %d 条: %v", len(sanitized), roles(sanitized))
+	}
+	if len(sanitized[1].ToolCalls) != 1 || sanitized[1].ToolCalls[0].ID != "c1" {
+		t.Fatalf("截断后 tool_call 应在 sanitize 后保留,got %+v", sanitized[1])
+	}
+	if sanitized[2].Role != "tool" || sanitized[2].ToolCallID != "c1" {
+		t.Fatalf("tool 响应应保留,got %+v", sanitized[2])
+	}
+	// 占位 JSON 必须能随整条消息正常序列化(避免 400)。
+	if _, err := json.Marshal(sanitized); err != nil {
+		t.Fatalf("截断后消息无法序列化: %v", err)
+	}
+}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><!DOCTYPE html><h1 cid="n0" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 2.25em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.2; cursor: text; border-bottom: 1px solid rgb(238, 238, 238); white-space: pre-wrap; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain md-expand" style="box-sizing: border-box;">🐛 fix(agent): 发送前截断超大工具参数,规避 Novita 400 与 llama.cpp 500</span></h1><h2 cid="n2" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.75em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.225; cursor: text; border-bottom: 1px solid rgb(238, 238, 238); white-space: pre-wrap; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">背景与问题</span></h2><p cid="n3" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">deepx 在把模型生成的工具调用（</span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">tool_calls</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">）发回 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">chat/completions</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 请求时,会原样序列化 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">function.arguments</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 字符串,没有任何体积限制。当模型把整篇大文件内容内联进工具参数时,会触发两类不同后端的同类故障:</span></p><ol class="ol-list" start="" cid="n4" mdtype="list" style="box-sizing: border-box; margin: 0.8em 0px; padding-left: 30px; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="md-list-item" cid="n5" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n6" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">OpenRouter（tencent/hy3:free,Novita 独供后端）</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 直接拒单:</span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">HTTP 400 ... invalid_request_error</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">。</span></p></li><li class="md-list-item" cid="n7" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n8" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">本地 llama.cpp（如 Agents-A1-MTP-APEX）</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 报 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">HTTP 500</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">:</span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">parse error at line 1, column 27456 ... missing closing quote</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">。</span></p></li></ol><p cid="n9" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">两者根因相同:单个工具调用的 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">arguments</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 过大(实测约 27KB 的一整页 HTML 被作为 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">Write</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 参数内联)。</span></p><h2 cid="n10" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.75em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.225; cursor: text; border-bottom: 1px solid rgb(238, 238, 238); white-space: pre-wrap; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">修复方案</span></h2><p cid="n11" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">在 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">agent/llm.go</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 新增一个轻量护栏,在每次发请求前对 convo 里的工具参数做体积裁剪:</span></p><ul class="ul-list" cid="n12" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0.8em 0px; padding-left: 30px; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="md-list-item" cid="n13" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n14" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">常量 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">maxToolArgBytes = 16 * 1024</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">(经验阈值:正常参数远小于此,只有"整篇文件内联"才会触顶,后续易调)。</span></p></li><li class="md-list-item" cid="n15" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n16" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">函数 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">truncateToolArgs(convo)</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">:遍历消息,对任一 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">tool_calls[*].function.arguments</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 超过阈值的,替换为一个合法 JSON 占位:</span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">{"_deepx_truncated":true,"original_bytes":N}</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">。</span></p></li><li class="md-list-item" cid="n17" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n18" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">集成到三处构造请求的入口:</span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">CallOnce</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">(非流式文本)、</span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">CallWithTools</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">(压缩摘要)、</span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">streamAttempt</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">(主循环流式,且顺序为 </span><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">truncate → sanitize,先截后消毒</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">)。</span></p></li></ul><h3 cid="n19" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.5em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.43; cursor: text; white-space: pre-wrap; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">关键设计点</span></h3><ul class="ul-list" cid="n20" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0.8em 0px; padding-left: 30px; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="md-list-item" cid="n21" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n22" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">替换成合法 JSON,而非从字符串中间硬切断</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">。硬切断会产生非法 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">tool_calls</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">,反而触发另一种 400;占位 JSON 保证请求仍是合法结构。</span></p></li><li class="md-list-item" cid="n23" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n24" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">作用于副本,不改原始对话</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">。</span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">truncateToolArgs</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 复制 convo 与 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">ToolCalls</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 切片,原始历史不动——工具此前已用完整参数执行过、结果在后续 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">tool</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 消息里,截断历史无害。</span></p></li><li class="md-list-item" cid="n25" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n26" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">只裁工具参数,不裁消息内容 / tool 结果</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">,改动面最小、对任务正确性影响最低。</span></p></li><li class="md-list-item" cid="n27" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n28" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">保留 tool_call ID</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">:截断只改 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">Arguments</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">,不动 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">ID</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">,因此截断后的 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">tool_call</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 仍能通过 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">sanitizeToolPairs</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 配对,不会被当作失配剥掉(这是 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">streamAttempt</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 里 truncate→sanitize 顺序正确性的前提,已用测试覆盖)。</span></p></li></ul><h2 cid="n29" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.75em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.225; cursor: text; border-bottom: 1px solid rgb(238, 238, 238); white-space: pre-wrap; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">验证</span></h2><ul class="ul-list" cid="n30" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0.8em 0px; padding-left: 30px; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="md-list-item" cid="n31" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n32" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">go build ./agent/</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">、</span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">go vet ./agent/</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">、</span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">go test ./agent/</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 全绿。</span></p></li><li class="md-list-item" cid="n33" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n34" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">复现任务(读取大 HTML → 原样写回)下:修复前某 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">Write</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 参数 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">argLen≈27455</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">;修复后该参数变为约 45 字节的占位 JSON,</span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">HTTP 400/500</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 不再出现,任务仍能正常完成(工具结果消息保留)。</span></p></li><li class="md-list-item" cid="n35" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n36" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">普通小参数任务不受影响(</span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">arguments</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 均 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">&lt; 16KB</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">,护栏对原始对话为 no-op)。</span></p></li></ul><h3 cid="n37" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.5em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.43; cursor: text; white-space: pre-wrap; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">新增测试 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: inherit;">agent/truncate_test.go</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">(6 例)</span></h3><figure class="md-table-fig" cid="n38" mdtype="table" style="box-sizing: border-box; margin: 1.2em 0px; overflow-x: auto; max-width: calc(100% + 16px); padding: 0px; cursor: default; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
测试 | 验证点
-- | --
TestTruncateNoOpWhenSmall | 小参数不截断、返回 truncated=false、原始 convo 未被改动(走副本)
TestTruncateLargeArg | 单条超大→替换为占位;占位是合法 JSON;original_bytes 等于原字节数;原 convo 不动
TestTruncateBoundary | 边界:恰好等于阈值不截 / 阈值+1 截(防 off-by-one)
TestTruncateMixedSizesSameMessage | 同一条 assistant 消息内多个 tool_calls,只截大的、保留小的,且 ID 保留
TestTruncateOnlyTargetsOversizedMessages | 多条消息只改含超大参数的那条,其余原样
TestTruncateSurvivesSanitize | 截断后仍能通过 sanitizeToolPairs 配对,且整条消息可正常序列化(避免 400)

</figure><h2 cid="n60" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.75em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.225; cursor: text; border-bottom: 1px solid rgb(238, 238, 238); white-space: pre-wrap; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">取舍与局限(请评审时重点关注)</span></h2><ol class="ol-list" start="" cid="n61" mdtype="list" style="box-sizing: border-box; margin: 0.8em 0px; padding-left: 30px; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="md-list-item" cid="n62" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n63" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">历史可读性</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">:被裁的参数在上下文中变成占位,模型日后"回忆刚才写了什么"会看不到原参数(但工具结果消息仍在,任务正确性不受影响)。这是为修 400/500 换来的取舍。</span></p></li><li class="md-list-item" cid="n64" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n65" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">对 OpenRouter 是直接修复;对 llama.cpp 是缓解而非绝对根治</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">。本地模型的 500 发生在"模型生成"侧(deepx 收不到合法 JSON 也就无从裁剪),本修复通过把上下文里那段 27KB 历史参数缩掉,降低模型再次尝试生成超大参数的概率与上下文压力,从而减少 500,但不能 100% 保证。要更彻底,需进一步限制消息内容 / tool 结果体积(更侵入,留作后续)。</span></p></li><li class="md-list-item" cid="n66" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n67" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">schema 校验风险</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">:占位 JSON 不遵守该工具的参数 schema。主流提供商会接受历史 assistant 消息里的 tool_calls(不按 schema 校验历史),但若有端点严格校验历史 tool_calls,可能另报 400——目前未观察到,列为已知风险。</span></p></li></ol><h2 cid="n68" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.75em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.225; cursor: text; border-bottom: 1px solid rgb(238, 238, 238); white-space: pre-wrap; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">备选方案(已考虑未采用)</span></h2><ul class="ul-list" cid="n69" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0.8em 0px; padding-left: 30px; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="md-list-item" cid="n70" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n71" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">provider_routing 忽略 Novita:对 hy3:free 无效(独供→404),且没碰根因。</span></p></li><li class="md-list-item" cid="n72" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n73" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">直接丢弃超大工具调用:过于激进,会丢失工具执行本身的上下文。</span></p></li><li class="md-list-item" cid="n74" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n75" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">在工具层(如 Write)限制入参:能治本但改动分散在各工具,不如在发送侧统一拦截通用。</span></p></li></ul><h2 cid="n76" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.75em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.225; cursor: text; border-bottom: 1px solid rgb(238, 238, 238); white-space: pre-wrap; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">改动文件</span></h2><ul class="ul-list" cid="n77" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0.8em 0px 0px; padding-left: 30px; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="md-list-item" cid="n78" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n79" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">agent/llm.go</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">:新增 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">maxToolArgBytes</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 常量与 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">truncateToolArgs</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 函数;在 </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">CallOnce</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> / </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">CallWithTools</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> / </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">streamAttempt</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> 三处发请求前接入。</span></p></li><li class="md-list-item md-focus-container" cid="n80" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n81" mdtype="paragraph" class="md-end-block md-p md-focus" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">agent/truncate_test.go</code></span><span md-inline="plain" class="md-plain md-expand" style="box-sizing: border-box;">:新增上述 6 个单元测试。</span></p></li></ul><!--EndFragment-->
</body>
</html>