### PR TITLE
✨ feat: 鼠标右键粘贴+F2切换穿透模式,支持终端原生选择

### DIFF
--- a/tui/model.go
+++ b/tui/model.go
@@ -28,6 +28,7 @@ import (
 	"charm.land/glamour/v2"
 	"charm.land/glamour/v2/styles"
 	"charm.land/lipgloss/v2"
+	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -208,6 +209,10 @@ type model struct {
 	// UpdatePlanStatus 通过 TaskStatusMsg 增量更新。每次新用户消息发起前清空。
 	plan     *planState
 	planKind string // 当前 plan 来源:"todo"(Todo)/ "createplan"(CreatePlan),右栏分段显示用
+
+	// mousePassthrough 为 true 时,在 View() 中关掉鼠标捕获(MouseModeNone),
+	// 让终端原生处理右键粘贴与文字选择。用 F2 切换。
+	mousePassthrough bool
 
 	// 鼠标 chat 矩形选区。selecting=true 表示左键在 chat 区按下后还没松开;
 	// selAnchor / selEnd 是选区两端 (cellPos: 显示列 + wrapped 行号)。
@@ -1460,6 +1465,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if msg.Button != tea.MouseLeft {
+			// 右键点击输入区 → 读取剪贴板文本并粘贴
+			if msg.Button == tea.MouseRight {
+				leftW, vpH := m.layout()
+				inInput := msg.Y >= vpH && msg.Y < m.height && msg.X >= 0 && msg.X < leftW
+				if inInput {
+					if text, err := clipboard.ReadAll(); err == nil && text != "" {
+						m.input.InsertString(text)
+					}
+				}
+			}
 			return m, nil
 		}
 		leftW, vpH := m.layout()
@@ -2476,6 +2491,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+b":
 			// 显示/隐藏右侧状态栏(chat 铺满整宽);记忆到 meta。
 			m.toggleStatusPanel()
+			return m, nil
+		case "f2":
+			// 切换鼠标穿透模式:关掉 MouseMode,让终端原生处理右键粘贴和文字选择。
+			m.mousePassthrough = !m.mousePassthrough
+			hint := "鼠标"
+			if m.mousePassthrough {
+				hint += "穿透已开启(终端原生选择/粘贴)"
+			} else {
+				hint += "捕获已恢复(deepx 选区/复制)"
+			}
+			m.appendChat("System", hint)
 			return m, nil
 		case "ctrl+v":
 			// 剪贴板有图就落盘并插入到输入框;没图则下落到 textinput 走文本粘贴。

--- a/tui/view.go
+++ b/tui/view.go
@@ -26,10 +26,9 @@ func (m model) wrapView(content string) tea.View {
 	v := tea.NewView(content)
 	v.AltScreen = true
 	v.MouseMode = tea.MouseModeCellMotion
-	// 文本输入类弹窗(填 API key / MCP / skill / web 配置)打开时关掉鼠标捕获,
-	// 让终端恢复原生右键粘贴(WSL2 / Windows Terminal 等)。否则鼠标模式开着时,
-	// 右键被当成鼠标事件吞掉,用户只能 Ctrl+V(见 issue #40)。这些弹窗内不需要拖拽/滚动。
-	if m.showSetup || m.showMcpAdd || m.showSkillAdd || m.showWebConfig {
+	// 鼠标穿透模式:关掉鼠标捕获,让终端原生处理右键粘贴与文字选择。
+	// 用户可按 F2 在 TUI 内切换,无需退出 deepx。
+	if m.mousePassthrough || m.showSetup || m.showMcpAdd || m.showSkillAdd || m.showWebConfig {
 		v.MouseMode = tea.MouseModeNone
 	}
 	// 换行键统一为 ctrl+j(LF,终端原生、不依赖 Kitty 协议、三平台一致,见 issue #124),
@@ -531,9 +530,15 @@ func (m model) statusFooterLine(_ int) string {
 			if m.turnToolCalls > 0 {
 				s += dim(" · " + strconv.Itoa(m.turnToolCalls) + " " + T("done.tools"))
 			}
+			if m.mousePassthrough {
+				s += dim(" · 🖱穿透")
+			}
 			return s
 		}
-		// 还没跑过任何一轮:留空。活动行的价值在"运行↔完成"的对比,启动时常挂个"就绪"只是噪音。
+		// 还没跑过任何一轮:检查鼠标穿透指示。
+		if m.mousePassthrough {
+			return dim("🖱 鼠标穿透已开启(F2切换)")
+		}
 		return ""
 	}
 	head := statusIcon(m.status)
@@ -548,6 +553,9 @@ func (m model) statusFooterLine(_ int) string {
 	// API 退避重试中:状态行实时显示「重试 N/10」,醒目色(对标 Claude Code 的 attempt 计数)。
 	if m.retryNotice != "" {
 		left += dim(" · ") + lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Bold(true).Render("⟳ "+m.retryNotice)
+	}
+	if m.mousePassthrough {
+		left += dim(" · 🖱穿透")
 	}
 	// 不再右贴 "Esc 中断" —— 输入框 placeholder(misc.input_placeholder)已含,避免重复。
 	return left


### PR DESCRIPTION
右键点击输入区自动粘贴剪贴板文本;
F2 切换鼠标穿透模式(MouseModeNone),让终端原生处理文字选择与右键粘贴;
状态栏显示 🖱穿透 指示器,三种状态下均可见。

Fixes #211