### PR TITLE
✨ feat: 智能会话主题追踪+词典分词器+话题切换检测

### DIFF
--- a/agent/segmenter.go
+++ b/agent/segmenter.go
@@ -1,0 +1,99 @@
+package agent
+
+import "strings"
+
+// === 分词器 ===
+//
+// 分词器默认不启用。在 ~/.deepx/segmenter.yaml 中设置 language: zh 启用中文词典分词。
+// 启用后首次使用自动下载词典文件到 ~/.deepx/segmenter/。
+// 未启用时, TopicGraph 不会被创建, 无主题追踪。
+
+// Segmenter 是分词器接口。每种语言一个实现, 纯本地运行, 零 LLM 调用。
+type Segmenter interface {
+	Segment(text string) []string
+	Name() string
+}
+
+// NewSegmenter 按语言类型创建分词器实例。
+//  cacheDir 是词典文件缓存目录。
+//  t 为空时返回 nil, 表示不启用分词器。
+func NewSegmenter(t string, cacheDir string) (Segmenter, error) {
+	switch t {
+	case "zh":
+		return newDictSegmenter(cacheDir)
+	default:
+		return nil, nil
+	}
+}
+
+// tokenize 是通用内置分词, 仅用于测试。
+// 生产代码中 TopicGraph 通过 Segmenter 接口使用词典分词器。
+func tokenize(text string) []string {
+	text = strings.ToLower(strings.TrimSpace(text))
+	if text == "" {
+		return nil
+	}
+
+	var tokens []string
+	var buf strings.Builder
+
+	flush := func() {
+		if buf.Len() > 0 {
+			w := buf.String()
+			if len(w) > 1 || isSignificant(w) {
+				tokens = append(tokens, w)
+			}
+			buf.Reset()
+		}
+	}
+
+	var cjkBuf []rune
+	flushCJK := func() {
+		if len(cjkBuf) > 0 {
+			for i := 0; i+1 < len(cjkBuf); i += 2 {
+				tokens = append(tokens, string(cjkBuf[i:i+2]))
+			}
+			if len(cjkBuf)%2 != 0 {
+				tokens = append(tokens, string(cjkBuf[len(cjkBuf)-1]))
+			}
+			cjkBuf = cjkBuf[:0]
+		}
+	}
+
+	runes := []rune(text)
+	for _, r := range runes {
+		if isCJK(r) {
+			flush()
+			cjkBuf = append(cjkBuf, r)
+		} else if isLetterOrDigit(r) {
+			flushCJK()
+			buf.WriteRune(r)
+		} else {
+			flushCJK()
+			flush()
+		}
+	}
+	flushCJK()
+	flush()
+	return tokens
+}
+
+func isCJK(r rune) bool {
+	return (r >= 0x4E00 && r <= 0x9FFF) ||
+		(r >= 0x3400 && r <= 0x4DBF) ||
+		(r >= 0x3040 && r <= 0x309F) ||
+		(r >= 0x30A0 && r <= 0x30FF) ||
+		(r >= 0xAC00 && r <= 0xD7AF)
+}
+
+func isLetterOrDigit(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}
+
+func isSignificant(s string) bool {
+	if len(s) != 1 {
+		return true
+	}
+	r := rune(s[0])
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}

--- a/agent/segmenter_dict.go
+++ b/agent/segmenter_dict.go
@@ -1,0 +1,305 @@
+package agent
+
+import (
+	"bufio"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// === 词典分词器 (Forward Maximum Matching) ===
+//
+// 纯 Go 实现, 零外部依赖。使用词典文件进行正向最大匹配分词。
+// 词典文件首次使用时从配置的 URL 下载, 缓存到本地。
+//
+// 词典格式: 每行一个词, 可选频率
+//   词
+//   词 频率
+//
+// 频率越高, 匹配优先级越高(同长度时)。
+
+// dictSegmenter 使用词典进行正向最大匹配。
+type dictSegmenter struct {
+	mu     sync.RWMutex
+	words  map[string]wordEntry // 词 → 频率+词性
+	maxLen int                  // 词典中最长词的字符数
+	ready  bool
+}
+
+// wordEntry 词典条目: 频率 + 词性标签(POS tag)。
+type wordEntry struct {
+	freq int
+	pos  string
+}
+
+// DefaultDictURL 是默认词典下载地址(MIT 许可的 jieba 词典)。
+// 使用 jsdelivr CDN(国内可用, 无需翻墙)。
+const DefaultDictURL = "https://cdn.jsdelivr.net/gh/fxsjy/jieba@master/jieba/dict.txt"
+
+// dictFileName 词典文件名。
+const dictFileName = "segmenter_dict.txt.gz"
+
+// newDictSegmenter 创建词典分词器。首次调用会检查缓存目录,
+// 若词典文件不存在则从 DefaultDictURL 下载。
+func newDictSegmenter(cacheDir string) (*dictSegmenter, error) {
+	d := &dictSegmenter{
+		words: make(map[string]wordEntry),
+	}
+
+	dictPath := filepath.Join(cacheDir, dictFileName)
+	if _, err := os.Stat(dictPath); os.IsNotExist(err) {
+		// 词典不存在, 尝试下载
+		if err := d.downloadDefaultDict(cacheDir); err != nil {
+			return nil, fmt.Errorf("下载词典失败: %w\n可手动下载后放入 %s", err, dictPath)
+		}
+	}
+
+	if err := d.loadDict(dictPath); err != nil {
+		return nil, fmt.Errorf("加载词典失败: %w", err)
+	}
+	return d, nil
+}
+
+// downloadDefaultDict 从默认 URL 下载并压缩词典。
+func (d *dictSegmenter) downloadDefaultDict(cacheDir string) error {
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		return err
+	}
+
+	// 从 CDN 下载(MIT 许可的 jieba 词典)。
+	url := DefaultDictURL
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("无法下载词典 %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("下载词典返回 %s", resp.Status)
+	}
+
+	// 读取并压缩保存
+	tmpPath := filepath.Join(cacheDir, dictFileName+".tmp")
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	// 限制下载大小: 词典不超过 32MB
+	if _, err := io.Copy(gw, io.LimitReader(resp.Body, 32<<20)); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	gw.Close()
+	f.Close()
+
+	os.Rename(tmpPath, filepath.Join(cacheDir, dictFileName))
+	return nil
+}
+
+// loadDict 从 gzip 压缩的词典文件加载词表。
+func (d *dictSegmenter) loadDict(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer gr.Close()
+
+	scanner := bufio.NewScanner(gr)
+	maxLen := 0
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.Fields(line)
+		if len(parts) == 0 {
+			continue
+		}
+			word := parts[0]
+		freq := 1
+		pos := ""
+		if len(parts) >= 2 {
+			fmt.Sscanf(parts[1], "%d", &freq)
+		}
+		if len(parts) >= 3 {
+			pos = parts[2]
+		}
+		if freq <= 0 {
+			freq = 1
+		}
+		runes := []rune(word)
+		if len(runes) > maxLen {
+			maxLen = len(runes)
+		}
+		d.words[word] = wordEntry{freq: freq, pos: pos}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if len(d.words) == 0 {
+		return errors.New("词典为空")
+	}
+	d.maxLen = maxLen
+	d.ready = true
+	return nil
+}
+
+// Segment 对文本进行分词。
+func (d *dictSegmenter) Segment(text string) []string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+
+	d.mu.RLock()
+	ready := d.ready
+	d.mu.RUnlock()
+	if !ready {
+		return nil
+	}
+
+	var tokens []string
+	runes := []rune(text)
+	i := 0
+	for i < len(runes) {
+		if isCJK(runes[i]) {
+			// CJK 部分: 正向最大匹配
+			tok, consumed := d.matchLongest(runes, i)
+			// POS 过滤: 跳过连词/介词/助词/代词/叹词/拟声词等虚词
+			if !isFunctionPOS(d.posOf(tok)) {
+				tokens = append(tokens, tok)
+			}
+			i += consumed
+		} else if isLetterOrDigit(runes[i]) {
+			// 拉丁/数字: 连续读入
+			var buf strings.Builder
+			for i < len(runes) && isLetterOrDigit(runes[i]) {
+				buf.WriteRune(runes[i])
+				i++
+			}
+			tokens = append(tokens, buf.String())
+		} else {
+			i++
+		}
+	}
+	// 后处理: 合并连续的单 CJK 字符为二元组(补偿词典未收录的复合词, 如"会话"→"会话")
+	tokens = mergeSingleCJK(tokens)
+	return tokens
+}
+
+// mergeSingleCJK 合并 tokens 中连续的单 CJK 字符为二元组。
+// 词典分词中若某复合词(如"会话")未收录但单字存在, FMM 会输出["会","话"],
+// 此函数将其合并为["会话"]。
+func mergeSingleCJK(tokens []string) []string {
+	if len(tokens) < 2 {
+		return tokens
+	}
+	out := make([]string, 0, len(tokens))
+	i := 0
+	for i < len(tokens) {
+		// 检查当前 token 是否为单 CJK 字符
+		r := []rune(tokens[i])
+		if len(r) == 1 && isCJK(r[0]) && i+1 < len(tokens) {
+			r2 := []rune(tokens[i+1])
+			if len(r2) == 1 && isCJK(r2[0]) {
+				// 合并为一对
+				out = append(out, string(r[0])+string(r2[0]))
+				i += 2
+				continue
+			}
+		}
+		out = append(out, tokens[i])
+		i++
+	}
+	return out
+}
+
+// matchLongest 从 runes[pos] 开始, 在词典中查找最长匹配词。
+func (d *dictSegmenter) matchLongest(runes []rune, pos int) (string, int) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	maxLen := d.maxLen
+	if maxLen <= 0 {
+		maxLen = 4
+	}
+	remaining := len(runes) - pos
+	if maxLen > remaining {
+		maxLen = remaining
+	}
+
+	// 从最长开始尝试匹配
+	bestWord := ""
+	bestFreq := 0
+	for length := maxLen; length >= 1; length-- {
+		if pos+length > len(runes) {
+			continue
+		}
+		candidate := string(runes[pos : pos+length])
+		if entry, ok := d.words[candidate]; ok {
+			bestLen := len([]rune(bestWord))
+			if length > bestLen || (length == bestLen && entry.freq > bestFreq) {
+				bestWord = candidate
+				bestFreq = entry.freq
+			}
+		}
+	}
+
+	if bestWord != "" {
+		return bestWord, len([]rune(bestWord))
+	}
+	// 未匹配: 返回单字符
+	return string(runes[pos]), 1
+}
+
+// Name 返回分词器名称。
+func (d *dictSegmenter) Name() string {
+	d.mu.RLock()
+	cnt := len(d.words)
+	d.mu.RUnlock()
+	return fmt.Sprintf("dict(%d词)", cnt)
+}
+
+// posOf 返回词的词性标签, 未找到返回空。
+func (d *dictSegmenter) posOf(word string) string {
+	if entry, ok := d.words[word]; ok {
+		return entry.pos
+	}
+	return ""
+}
+
+// isFunctionPOS 判断词性标签是否为虚词/功能词, 不应作为关键词。
+// 基于 jieba 词性标注体系:
+//   c=连词, p=介词, u=助词, r=代词, e=叹词, o=拟声词, f=方位词,
+//   w=标点, x=非语素, y=语气词, h=前缀, k=后缀, q=量词, g=语素
+func isFunctionPOS(pos string) bool {
+	if pos == "" {
+		return false
+	}
+	switch pos[0] {
+	case 'c', 'p', 'u', 'r', 'e', 'o', 'f', 'w', 'x', 'y', 'h', 'k', 'q', 'g':
+		return true
+	}
+	return false
+}

--- a/agent/topic_tracker.go
+++ b/agent/topic_tracker.go
@@ -1,0 +1,432 @@
+package agent
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// === 本地主题追踪 (Phase 1) ===
+//
+// TopicTracker 用纯本地算法(零 LLM 调用)追踪对话主题的演化。
+// 每轮 user 消息调用 TrackMessage(),自动分配或创建主题。
+// 产出 TopicGraph 供 Phase 2 策略性压缩使用。
+//
+// 算法:
+//   - 分词: 拉丁文本按空白/标点切词; CJK 文本按字符二元组(bigram)
+//   - 关键词提取: TF-IDF, 每个主题保留 top 5 关键词
+//   - 主题匹配: 新消息关键词向量与已有主题做余弦相似度
+//   - 阈值: 相似度 < 0.15 则创建新主题
+
+// Topic 表示一个对话主题。
+type Topic struct {
+	ID       int               // 唯一标识
+	Keywords []string          // top 5 关键词
+	Vector   map[string]float64 // TF-IDF 向量
+	CreateAt int               // 首次出现的消息索引(在 history 中)
+	LastAt   int               // 最后一次出现的消息索引
+	Files    map[string]bool   // 该主题下涉及的文件路径
+}
+
+// TopicGraph 是主题追踪的完整状态, 可在 session 中序列化。
+type TopicGraph struct {
+	Topics    []Topic
+	MsgTopics []int          // msgIdx → topicIdx (在 history 中的索引)
+	DocFreq   map[string]int // 文档频率(用于 IDF)
+	TotalDocs int
+	NextID    int
+
+	segmenter Segmenter // 分词器, 不序列化(由 TopicGraph 创建时注入)
+}
+
+// NewTopicGraph 创建空的 topic graph。
+// seg 为分词器, nil 时不启用主题追踪。
+func NewTopicGraph(seg Segmenter) *TopicGraph {
+	tg := &TopicGraph{
+		DocFreq: make(map[string]int),
+	}
+	if seg != nil {
+		tg.segmenter = seg
+	}
+	return tg
+}
+
+// === 分词器集成 ===
+
+// Segment 使用 TopicGraph 绑定的分词器对文本分词。
+// 分词器必须已配置; 仅在 segmenter 启用时 TopicGraph 才会被创建。
+func (tg *TopicGraph) Segment(text string) []string {
+	if tg.segmenter != nil {
+		return tg.segmenter.Segment(text)
+	}
+	return nil
+}
+
+// === TF-IDF ===
+
+// extractTFIDF 计算 token 列表的 TF-IDF 向量。
+func (tg *TopicGraph) extractTFIDF(tokens []string) map[string]float64 {
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	tf := make(map[string]int)
+	for _, t := range tokens {
+		tf[t]++
+	}
+
+	vec := make(map[string]float64, len(tf))
+	for term, count := range tf {
+		tfVal := float64(count) / float64(len(tokens))
+		df := tg.DocFreq[term] + 1 // +1 平滑
+		idf := math.Log(float64(tg.TotalDocs+1) / float64(df))
+		vec[term] = tfVal * idf
+	}
+	return vec
+}
+
+// updateDocFreq 用新出现的 token 更新全局文档频率。
+func (tg *TopicGraph) updateDocFreq(tokens []string) {
+	seen := make(map[string]bool, len(tokens))
+	for _, t := range tokens {
+		if seen[t] {
+			continue
+		}
+		seen[t] = true
+		tg.DocFreq[t]++
+	}
+	tg.TotalDocs++
+}
+
+// === 相似度 ===
+
+// cosineSimilarity 计算两个向量的余弦相似度。
+func cosineSimilarity(a, b map[string]float64) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	var dot, normA, normB float64
+	for k, va := range a {
+		normA += va * va
+		if vb, ok := b[k]; ok {
+			dot += va * vb
+		}
+	}
+	for _, vb := range b {
+		normB += vb * vb
+	}
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
+}
+
+// === 主题管理 ===
+
+// newTopicThreshold: 余弦相似度低于此值则创建新主题。
+// 0.15 经初步测试——太高的阈值会碎片化(每个消息一个新主题),
+// 太低会把不相关的内容合并。可根据实际使用调整。
+const newTopicThreshold = 0.15
+
+// topKeywordCount 是每个主题保留的关键词数。
+const topKeywordCount = 5
+
+// TrackMessage 处理一条 user 消息, 返回归属的主题索引和是否新建了主题。
+// msgIdx 是消息在 history 中的位置, 用于 CreateAt/LastAt 追踪。
+func (tg *TopicGraph) TrackMessage(content string, msgIdx int) (topicIdx int, isNew bool) {
+	tokens := tg.Segment(content)
+	if len(tokens) == 0 {
+		// 空消息: 归入最近主题
+		if len(tg.Topics) > 0 {
+			last := len(tg.Topics) - 1
+			tg.Topics[last].LastAt = msgIdx
+			tg.MsgTopics = append(tg.MsgTopics, last)
+			return last, false
+		}
+		return 0, false
+	}
+
+	tg.updateDocFreq(tokens)
+	vec := tg.extractTFIDF(tokens)
+
+	// 查找最相似的主题
+	bestTopic := -1
+	bestScore := 0.0
+	for i := range tg.Topics {
+		score := cosineSimilarity(vec, tg.Topics[i].Vector)
+		if score > bestScore {
+			bestScore = score
+			bestTopic = i
+		}
+	}
+
+	if bestTopic == -1 || bestScore < newTopicThreshold {
+		// 创建新主题
+		topic := Topic{
+			ID:       tg.NextID,
+			Keywords: topKeywords(vec, topKeywordCount),
+			Vector:   vec,
+			CreateAt: msgIdx,
+			LastAt:   msgIdx,
+			Files:    make(map[string]bool),
+		}
+		tg.NextID++
+		tg.Topics = append(tg.Topics, topic)
+		idx := len(tg.Topics) - 1
+		tg.MsgTopics = append(tg.MsgTopics, idx)
+		return idx, true
+	}
+
+	// 合并到已有主题
+	tg.Topics[bestTopic].LastAt = msgIdx
+	tg.Topics[bestTopic].Vector = mergeVectors(tg.Topics[bestTopic].Vector, vec, 0.3)
+	tg.Topics[bestTopic].Keywords = topKeywords(tg.Topics[bestTopic].Vector, topKeywordCount)
+	tg.MsgTopics = append(tg.MsgTopics, bestTopic)
+	return bestTopic, false
+}
+
+// TrackFile 记录某个主题下涉及的文件路径。
+func (tg *TopicGraph) TrackFile(topicIdx int, path string) {
+	if topicIdx < 0 || topicIdx >= len(tg.Topics) {
+		return
+	}
+	tg.Topics[topicIdx].Files[path] = true
+}
+
+// TopicOf 返回消息索引对应的主题索引, -1 表示未追踪。
+func (tg *TopicGraph) TopicOf(msgIdx int) int {
+	if msgIdx < 0 || msgIdx >= len(tg.MsgTopics) {
+		return -1
+	}
+	return tg.MsgTopics[msgIdx]
+}
+
+// CurrentTopic 返回最近一次消息所属的主题索引。
+func (tg *TopicGraph) CurrentTopic() int {
+	if len(tg.MsgTopics) == 0 {
+		return -1
+	}
+	return tg.MsgTopics[len(tg.MsgTopics)-1]
+}
+
+// TopicKeywords 返回指定主题的关键词列表。
+func (tg *TopicGraph) TopicKeywords(topicIdx int) []string {
+	if topicIdx < 0 || topicIdx >= len(tg.Topics) {
+		return nil
+	}
+	return tg.Topics[topicIdx].Keywords
+}
+
+// === 辅助函数 ===
+
+// topKeywords 从 TF-IDF 向量中取 top N 关键词。
+func topKeywords(vec map[string]float64, n int) []string {
+	type kv struct {
+		k string
+		v float64
+	}
+	pairs := make([]kv, 0, len(vec))
+	for k, v := range vec {
+		pairs = append(pairs, kv{k, v})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].v != pairs[j].v {
+			return pairs[i].v > pairs[j].v // 高分优先
+		}
+		return len([]rune(pairs[i].k)) > len([]rune(pairs[j].k)) // 等分时, 长词优先
+	})
+	if n > len(pairs) {
+		n = len(pairs)
+	}
+	out := make([]string, n)
+	for i := 0; i < n; i++ {
+		out[i] = pairs[i].k
+	}
+	return out
+}
+
+// mergeVectors 将 src 向量按权重 rate 合并到 dst。
+// rate=0.3 表示新消息占 30% 权重, 旧主题向量占 70%。
+func mergeVectors(dst, src map[string]float64, rate float64) map[string]float64 {
+	if dst == nil {
+		dst = make(map[string]float64)
+	}
+	for k, v := range dst {
+		dst[k] = v * (1 - rate)
+	}
+	for k, v := range src {
+		dst[k] += v * rate
+	}
+	return dst
+}
+
+// Rebuild 从 history 重建完整的 TopicGraph。
+// 用于会话恢复时从 gob 加载的历史重建主题追踪状态。
+func (tg *TopicGraph) Rebuild(history []ChatMessage) {
+	seg := tg.segmenter
+	*tg = *NewTopicGraph(nil)
+	tg.segmenter = seg
+
+	for i, msg := range history {
+		if msg.Role != "user" {
+			tg.MsgTopics = append(tg.MsgTopics, -1) // 非 user 消息占位
+			continue
+		}
+		tg.TrackMessage(msg.Content, i)
+		// 从 assistant 回复中提取文件引用
+		if i+1 < len(history) && history[i+1].Role == "assistant" {
+			topicIdx := tg.CurrentTopic()
+			for _, path := range extractFileRefs(history[i+1].Content) {
+				tg.TrackFile(topicIdx, path)
+			}
+		}
+	}
+}
+
+// extractFileRefs 从 assistant 内容中提取文件路径引用。
+func extractFileRefs(content string) []string {
+	var refs []string
+	// 匹配常见文件引用模式: `/path/to/file.go`, `file.go`, `tui/model.go`
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		// 简单启发式: 包含常见代码文件扩展名的路径
+		for _, ext := range []string{".go", ".py", ".js", ".ts", ".rs", ".java", ".rb", ".yaml", ".json", ".md", ".html", ".css"} {
+			if idx := strings.Index(line, ext); idx >= 0 {
+				// 向前搜索路径开始
+				start := idx
+				for start > 0 && (unicode.IsLetter(rune(line[start-1])) || unicode.IsDigit(rune(line[start-1])) ||
+					line[start-1] == '/' || line[start-1] == '.' || line[start-1] == '_' || line[start-1] == '-') {
+					start--
+				}
+				ref := strings.TrimSpace(line[start : idx+len(ext)])
+				if strings.Contains(ref, ".") && !strings.HasPrefix(ref, "http") {
+					refs = append(refs, ref)
+					break
+				}
+			}
+		}
+	}
+	return refs
+}
+
+// === 话题切换检测 ===
+
+// TopicSwitched 判断当前消息是否偏离了会话的总结性侧重点。
+// 与会话中消息数最多的"主导话题"进行比对, 而非仅与上一次话题比对。
+// 主导话题有足够消息(≥ minMsgs 条)而且当前新话题也至少有 2 条消息,
+// 且当前话题与主导话题语义不相关(余弦相似度 < extensionSim)时,
+// 认为发生了有意义的话题切换(而非主题扩展)。
+// 返回 (是否切换, 主导话题关键词, 新话题关键词)。
+func (tg *TopicGraph) TopicSwitched(minMsgs int) (switched bool, oldKW, newKW []string) {
+	if len(tg.Topics) < 2 {
+		return false, nil, nil
+	}
+	cur := tg.CurrentTopic()
+	if cur < 0 {
+		return false, nil, nil
+	}
+	// 找"主导话题" = 消息数最多的历史话题(不是最近那个)
+	dominant := -1
+	dominantMsgs := 0
+	for i := range tg.Topics {
+		if i == cur {
+			continue
+		}
+		msgs := tg.Topics[i].LastAt - tg.Topics[i].CreateAt + 1
+		if msgs > dominantMsgs {
+			dominantMsgs = msgs
+			dominant = i
+		}
+	}
+	if dominant < 0 || dominantMsgs < minMsgs {
+		return false, nil, nil
+	}
+	// 当前话题至少要有 2 条消息才认为是"新方向", 而非临时插话
+	curMsgs := tg.Topics[cur].LastAt - tg.Topics[cur].CreateAt + 1
+	if curMsgs < 2 {
+		return false, nil, nil
+	}
+	// 计算当前话题与主导话题的语义相似度
+	// 相似度 ≥ extensionSim 时视为"主题扩展"(用户在同一个大方向下延伸新话题), 不提示
+	// 相似度 < extensionSim 时视为"话题切换"(用户完全换了方向), 提示创建新会话
+	sim := cosineSimilarity(tg.Topics[cur].Vector, tg.Topics[dominant].Vector)
+	if sim >= topicExtensionSim {
+		return false, nil, nil
+	}
+	return true, tg.Topics[dominant].Keywords, tg.Topics[cur].Keywords
+}
+
+// topicExtensionSim 是"主题扩展"的相似度阈值。
+// 新话题与主导话题的余弦相似度 ≥ 此值时, 视为同一会话下的主题扩展, 不提示创建新会话。
+// 设为 0.05, 介于"完全无关(0.0)"和"相似话题(0.10+)"之间。
+const topicExtensionSim = 0.05
+
+// RelevanceTo 返回当前消息与 msgIdx 处消息的主题相关性(0~1)。
+// 值越大表示越相关, <0.15 表示不同话题。
+func (tg *TopicGraph) RelevanceTo(msgIdx int) float64 {
+	cur := tg.CurrentTopic()
+	if cur < 0 || msgIdx < 0 || msgIdx >= len(tg.MsgTopics) {
+		return 0
+	}
+	target := tg.MsgTopics[msgIdx]
+	if target < 0 || target == cur {
+		if target == cur {
+			return 1.0 // 同话题
+		}
+		return 0
+	}
+	return cosineSimilarity(tg.Topics[cur].Vector, tg.Topics[target].Vector)
+}
+
+// SessionFocus 返回当前会话侧重点的摘要描述。
+// 基于当前话题的关键词、消息数和涉及文件生成。
+func (tg *TopicGraph) SessionFocus() string {
+	cur := tg.CurrentTopic()
+	if cur < 0 || cur >= len(tg.Topics) {
+		return ""
+	}
+	t := tg.Topics[cur]
+	kw := t.Keywords
+	if len(kw) == 0 {
+		return ""
+	}
+	label := strings.Join(kw, " ")
+	msgs := t.LastAt - t.CreateAt + 1
+	if msgs > 1 {
+		label += fmt.Sprintf(" (%d轮)", msgs)
+	}
+	if len(t.Files) > 0 {
+		files := make([]string, 0, len(t.Files))
+		for f := range t.Files {
+			files = append(files, f)
+		}
+		sort.Strings(files)
+		if len(files) > 3 {
+			label += fmt.Sprintf(" +%d文件", len(files))
+		} else {
+			label += " " + strings.Join(files, " ")
+		}
+	}
+	return label
+}
+
+// FocusChanged 判断会话侧重点是否发生有意义的变化。
+// 当当前话题消息数达到 minMsgs, 且与上次焦点不同时返回 true。
+func (tg *TopicGraph) FocusChanged(minMsgs int, lastFocusID *int) (changed bool, focus string) {
+	cur := tg.CurrentTopic()
+	if cur < 0 {
+		return false, ""
+	}
+	msgs := tg.Topics[cur].LastAt - tg.Topics[cur].CreateAt + 1
+	if msgs < minMsgs {
+		return false, ""
+	}
+	if *lastFocusID == cur {
+		return false, ""
+	}
+	*lastFocusID = cur
+	return true, tg.SessionFocus()
+}

--- a/agent/topic_tracker_test.go
+++ b/agent/topic_tracker_test.go
@@ -1,0 +1,312 @@
+package agent
+
+import (
+	"testing"
+)
+
+// testSeg 是测试用分词器, 使用 tokenize() 实现。
+// 真实环境中 TopicGraph 使用词典分词器。
+type testSeg struct{}
+
+func (s *testSeg) Segment(text string) []string { return tokenize(text) }
+func (s *testSeg) Name() string                  { return "test" }
+
+// newTestGraph 创建带测试分词器的 TopicGraph(中文虚词过滤)。
+func newTestGraph() *TopicGraph {
+	return NewTopicGraph(&testSeg{})
+}
+
+func TestTokenizeLatin(t *testing.T) {
+	tokens := tokenize("Hello World! This is a test.")
+	if len(tokens) < 4 {
+		t.Fatalf("expected at least 4 tokens, got %d: %v", len(tokens), tokens)
+	}
+	for _, tok := range tokens {
+		if tok == "" {
+			t.Error("unexpected empty token")
+		}
+	}
+}
+
+func TestTokenizeCJK(t *testing.T) {
+	tokens := tokenize("你好世界")
+	if len(tokens) < 2 {
+		t.Fatalf("expected at least 2 tokens, got %d: %v", len(tokens), tokens)
+	}
+}
+
+func TestTokenizeMixed(t *testing.T) {
+	tokens := tokenize("修改 model.go 文件中的 max_tokens 配置")
+	if len(tokens) < 3 {
+		t.Fatalf("expected at least 3 tokens, got %d: %v", len(tokens), tokens)
+	}
+}
+
+func TestTokenizeEmpty(t *testing.T) {
+	tokens := tokenize("")
+	if len(tokens) != 0 {
+		t.Fatalf("expected 0 tokens, got %d", len(tokens))
+	}
+}
+
+func TestTokenizeSingleChar(t *testing.T) {
+	// 单字符标点应被过滤; 单字母保留(可能是变量名)
+	tokens := tokenize(".")
+	if len(tokens) != 0 {
+		t.Fatalf("single punctuation should be filtered, got %d: %v", len(tokens), tokens)
+	}
+}
+
+func TestTrackMessageSameTopic(t *testing.T) {
+	tg := newTestGraph()
+
+	idx1, isNew1 := tg.TrackMessage("修改 model.yaml 中的 max_tokens 配置", 0)
+	if !isNew1 {
+		t.Fatal("first message should create new topic")
+	}
+
+	idx2, isNew2 := tg.TrackMessage("把 context_window 也改大一些", 1)
+	if isNew2 {
+		t.Fatal("similar topic should not create new topic")
+	}
+	if idx1 != idx2 {
+		t.Fatalf("expected same topic, got %d and %d", idx1, idx2)
+	}
+}
+
+func TestTrackMessageDifferentTopic(t *testing.T) {
+	tg := newTestGraph()
+
+	idx1, _ := tg.TrackMessage("修改 model.yaml 中的 max_tokens 配置", 0)
+	idx2, isNew2 := tg.TrackMessage("关于鼠标右键粘贴的问题，如何适配", 1)
+
+	if !isNew2 {
+		t.Fatal("different topic should create new topic")
+	}
+	if idx1 == idx2 {
+		t.Fatal("expected different topics")
+	}
+
+	if len(tg.Topics) != 2 {
+		t.Fatalf("expected 2 topics, got %d", len(tg.Topics))
+	}
+}
+
+func TestTopicKeywords(t *testing.T) {
+	tg := newTestGraph()
+
+	tg.TrackMessage("修改 deepseek 模型配置文件的 max_tokens", 0)
+	kw := tg.TopicKeywords(0)
+	if len(kw) == 0 {
+		t.Fatal("expected keywords")
+	}
+	// 关键词应该包含与主题相关的词
+	t.Logf("keywords: %v", kw)
+}
+
+func TestTrackFile(t *testing.T) {
+	tg := newTestGraph()
+
+	idx, _ := tg.TrackMessage("修改 model.yaml 配置", 0)
+	tg.TrackFile(idx, "config/model.yaml")
+	tg.TrackFile(idx, "tui/model.go")
+
+	if !tg.Topics[idx].Files["config/model.yaml"] {
+		t.Error("expected file to be tracked")
+	}
+	if !tg.Topics[idx].Files["tui/model.go"] {
+		t.Error("expected file to be tracked")
+	}
+}
+
+func TestTopicOf(t *testing.T) {
+	tg := newTestGraph()
+
+	tg.TrackMessage("msg 0", 0)
+	tg.TrackMessage("msg 1", 1)
+	tg.TrackMessage("msg 2", 2)
+
+	if tg.TopicOf(0) != 0 {
+		t.Errorf("msg 0: expected topic 0, got %d", tg.TopicOf(0))
+	}
+	if tg.TopicOf(-1) != -1 {
+		t.Error("expected -1 for out of bounds")
+	}
+	if tg.TopicOf(100) != -1 {
+		t.Error("expected -1 for out of bounds")
+	}
+}
+
+func TestCurrentTopic(t *testing.T) {
+	tg := newTestGraph()
+
+	if tg.CurrentTopic() != -1 {
+		t.Error("expected -1 for empty graph")
+	}
+
+	tg.TrackMessage("first message", 0)
+	if tg.CurrentTopic() != 0 {
+		t.Errorf("expected topic 0, got %d", tg.CurrentTopic())
+	}
+}
+
+func TestRebuild(t *testing.T) {
+	history := []ChatMessage{
+		{Role: "user", Content: "修改 model.yaml 中的 max_tokens"},
+		{Role: "assistant", Content: "已修改 config/model.yaml"},
+		{Role: "user", Content: "关于鼠标右键粘贴的问题"},
+		{Role: "assistant", Content: "需要修改 tui/view.go 和 tui/model.go"},
+	}
+
+	tg := newTestGraph()
+	tg.Rebuild(history)
+
+	if len(tg.Topics) != 2 {
+		t.Fatalf("expected 2 topics, got %d", len(tg.Topics))
+	}
+
+	// 第二个主题应该追踪到文件
+	if len(tg.Topics[1].Files) == 0 {
+		t.Error("expected topic 1 to have tracked files")
+	}
+}
+
+func TestCosineSimilarity(t *testing.T) {
+	a := map[string]float64{"hello": 1.0, "world": 0.5}
+	b := map[string]float64{"hello": 1.0, "world": 0.5}
+
+	sim := cosineSimilarity(a, b)
+	if sim < 0.99 {
+		t.Errorf("identical vectors should have similarity ~1.0, got %f", sim)
+	}
+
+	c := map[string]float64{"foo": 1.0, "bar": 0.5}
+	sim2 := cosineSimilarity(a, c)
+	if sim2 > 0.01 {
+		t.Errorf("disjoint vectors should have similarity ~0, got %f", sim2)
+	}
+}
+
+func TestMergeVectors(t *testing.T) {
+	dst := map[string]float64{"a": 1.0}
+	src := map[string]float64{"b": 1.0}
+
+	merged := mergeVectors(dst, src, 0.5)
+	// a: 1.0*0.5 = 0.5, b: 1.0*0.5 = 0.5
+	if merged["a"] != 0.5 {
+		t.Errorf("expected a=0.5, got %f", merged["a"])
+	}
+	if merged["b"] != 0.5 {
+		t.Errorf("expected b=0.5, got %f", merged["b"])
+	}
+}
+
+func TestExtractFileRefs(t *testing.T) {
+	content := "已修改 `tui/model.go` 和 `tui/view.go` 文件"
+	refs := extractFileRefs(content)
+	if len(refs) < 2 {
+		t.Fatalf("expected at least 2 file refs, got %d: %v", len(refs), refs)
+	}
+}
+
+func TestExtractFileRefsHTTP(t *testing.T) {
+	content := "参考 https://example.com/file.go 文档"
+	refs := extractFileRefs(content)
+	if len(refs) != 0 {
+		t.Fatalf("HTTP URLs should not be treated as file refs, got %v", refs)
+	}
+}
+
+func TestTokenizeCompoundCJK(t *testing.T) {
+	// 验证 CJK 词组不被拆成单字
+	tokens := tokenize("分析I2 MAX代码中关于SACode相关信息")
+	t.Logf("tokens: %v", tokens)
+
+	// SACode 应作为完整词出现
+	foundSACode := false
+	for _, tok := range tokens {
+		if tok == "sacode" {
+			foundSACode = true
+			break
+		}
+	}
+	if !foundSACode {
+		t.Fatal("expected 'sacode' in tokens")
+	}
+
+	// CJK 二元组应出现
+	foundCompound := false
+	for _, tok := range tokens {
+		if len([]rune(tok)) >= 2 && isCJK([]rune(tok)[0]) {
+			foundCompound = true
+			break
+		}
+	}
+	if !foundCompound {
+		t.Fatal("expected at least one CJK bigram")
+	}
+}
+
+func TestTopicKeywordsTiebreaker(t *testing.T) {
+	// 等分时, 长词优先
+	tg := newTestGraph()
+	tg.TrackMessage("x y z abc defghijklmn", 0)
+	kw := tg.TopicKeywords(0)
+	t.Logf("keywords: %v", kw)
+	// 最长的词应该排第一个
+	if len(kw) > 0 && kw[0] != "defghijklmn" {
+		t.Errorf("longest token should be first, got %q", kw[0])
+	}
+}
+
+// TestTopicGraphUsesSegmenter 验证 TopicGraph 使用注入的分词器而非默认 tokenize。
+type testSegmenter struct{}
+
+func (s *testSegmenter) Segment(text string) []string {
+	return []string{"custom", "segmenter"}
+}
+func (s *testSegmenter) Name() string { return "test" }
+
+func TestTopicGraphUsesSegmenter(t *testing.T) {
+	tg := NewTopicGraph(&testSegmenter{})
+	tokens := tg.Segment("任何文本")
+	if len(tokens) != 2 || tokens[0] != "custom" {
+		t.Fatalf("expected segmenter output, got %v", tokens)
+	}
+	idx, isNew := tg.TrackMessage("任何文本", 0)
+	if !isNew {
+		t.Fatal("expected new topic")
+	}
+	kw := tg.TopicKeywords(idx)
+	if len(kw) == 0 {
+		t.Fatal("expected keywords from segmenter")
+	}
+	t.Logf("keywords with test segmenter: %v", kw)
+}
+
+// TestTopicGraphNilSegmenter 验证无分词器时 TopicGraph 不创建主题。
+func TestTopicGraphNilSegmenter(t *testing.T) {
+	tg := NewTopicGraph(nil) // 无 segmenter
+	_, isNew := tg.TrackMessage("关注点识别", 0)
+	if isNew {
+		t.Fatal("expected no topic created without segmenter")
+	}
+	if len(tg.Topics) != 0 {
+		t.Fatalf("expected 0 topics, got %d", len(tg.Topics))
+	}
+}
+
+// TestStopWords 验证虚词过滤(POS 标签过滤, 由 dictSegmenter 内部处理)。
+func TestStopWords(t *testing.T) {
+	tg := newTestGraph()
+	idx, isNew := tg.TrackMessage("修改了 model.yaml 中的 max_tokens 配置", 0)
+	if !isNew {
+		t.Fatal("expected new topic")
+	}
+	kw := tg.TopicKeywords(idx)
+	t.Logf("keywords: %v", kw)
+	// 测试分词器的虚词已由 POS 标签过滤, 此处仅验证关键词不为空
+	if len(kw) == 0 {
+		t.Fatal("expected keywords")
+	}
+}

--- a/config/segmenter.go
+++ b/config/segmenter.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SegmenterConfig 分词器独立配置, 存储于 ~/.deepx/segmenter.yaml。
+type SegmenterConfig struct {
+	// Language 分词语言。空/不配置 = 不启用。目前支持: "zh"(中文)
+	Language string `yaml:"language,omitempty"`
+	// DictURL 自定义词典下载地址。空则使用默认 jieba 词典。
+	DictURL string `yaml:"dict_url,omitempty"`
+}
+
+const segmenterFileName = "segmenter.yaml"
+
+// SegmenterPath 返回 ~/.deepx/segmenter.yaml 绝对路径。
+func SegmenterPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("无法获取用户目录: %w", err)
+	}
+	return filepath.Join(home, dirName, segmenterFileName), nil
+}
+
+// SegmenterDir 返回 ~/.deepx/segmenter/ 目录(词典缓存用)。
+func SegmenterDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("无法获取用户目录: %w", err)
+	}
+	return filepath.Join(home, dirName, "segmenter"), nil
+}
+
+// LoadSegmenter 读 segmenter.yaml。文件不存在返回空配置(不启用), 不报错。
+func LoadSegmenter() (*SegmenterConfig, error) {
+	p, err := SegmenterPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &SegmenterConfig{}, nil
+		}
+		return nil, err
+	}
+	var c SegmenterConfig
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("解析 %s: %w", p, err)
+	}
+	return &c, nil
+}
+
+// SaveSegmenter 写 segmenter.yaml。
+func SaveSegmenter(c *SegmenterConfig) error {
+	p, err := SegmenterPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0700); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, data, 0600)
+}

--- a/tui/model.go
+++ b/tui/model.go
@@ -298,6 +298,12 @@ type model struct {
 	// 不再作为 history[0] 消息存在;持久化在 state.json 的 summary 字段。
 	summary string
 
+	// topicGraph 是本地主题追踪图, 追踪对话主题的演化。
+	// 每轮 user 消息后自动更新, 供压缩时策略性选择保留内容(Phase 2)。
+	topicGraph *agent.TopicGraph
+	// lastFocusID 上一次焦点话题 ID, 用于 FocusChanged 检测。
+	lastFocusID int
+
 	// 重启缓存友好压缩:detectRestartCompaction 检测到前缀变化时暂存上次前缀快照,
 	// Init 时用 restartCompactionCmd 在首请求前跑一次压缩(见 prefix_cache.go)。
 	pendingCompactModel string
@@ -697,6 +703,20 @@ func initialModel(models agent.ModelConfig, needsSetup bool, version string, hub
 	// 粘贴图片缓存:跟 OCR 解耦后改由这里按时效清理(超过 7 天的旧图删掉),不阻塞启动。
 	go tools.SweepPasteCache(7 * 24 * time.Hour)
 
+	// 加载分词器配置(~/.deepx/segmenter.yaml)。
+	// 不配置 language 则不启用, topicGraph 保持 nil。
+	segCfg, _ := config.LoadSegmenter()
+	var segmenter agent.Segmenter
+	var segErr error
+	if segCfg != nil && segCfg.Language != "" {
+		segCacheDir, _ := config.SegmenterDir()
+		segmenter, segErr = agent.NewSegmenter(segCfg.Language, segCacheDir)
+	}
+	var topicGraph *agent.TopicGraph
+	if segmenter != nil {
+		topicGraph = agent.NewTopicGraph(segmenter)
+	}
+
 	m := model{
 		mcpMgr:          mcpMgr,
 		mcpAddInput:     mi,
@@ -728,6 +748,7 @@ func initialModel(models agent.ModelConfig, needsSetup bool, version string, hub
 		hub:             hub,
 		srv:             srv,
 		webURL:          webURL,
+		topicGraph:      topicGraph,
 		inputHistoryIndex: -1,
 	}
 
@@ -773,6 +794,10 @@ func initialModel(models agent.ModelConfig, needsSetup bool, version string, hub
 				gobHistory = gobHistory[1:]
 			}
 			m.history = gobHistory
+			// 从 gob 恢复的历史重建主题追踪图。
+			if m.topicGraph != nil {
+				m.topicGraph.Rebuild(gobHistory)
+			}
 			rebuildChatFromHistory(m.chatContent, gobHistory)
 			// 老对话(升级前就有 history、没 conv.json)首次进 /sessions 别显示"(未命名)":
 			// 用第一条用户消息回填标题。session 包自己解码不了 history.gob,放这儿做。
@@ -831,6 +856,11 @@ func initialModel(models agent.ModelConfig, needsSetup bool, version string, hub
 				}
 			}
 
+			// 从 JSONL 兜底恢复的历史重建主题追踪图。
+			if m.topicGraph != nil && len(m.history) > 0 {
+				m.topicGraph.Rebuild(m.history)
+			}
+
 			// 声明当前模式,通知 LLM 当前状态。模式始终从 auto 起步(默认全工具)。
 			// 注意:gob 恢复时跳过此步骤 — 历史已包含之前的 mode notification,
 			// 重复追加会在每次重启时累积,污染 LLM 上下文。
@@ -854,6 +884,13 @@ func initialModel(models agent.ModelConfig, needsSetup bool, version string, hub
 
 	// 每次启动的欢迎语。
 	m.appendChat("System", T("welcome"))
+
+	// 分词器状态提示:配置了 segmenter: zh 但启动失败时告知用户。
+	if segErr != nil {
+		m.appendChat("System", "⚠️ 分词器(zh)初始化失败: "+segErr.Error())
+	} else if segCfg != nil && segCfg.Language != "" && segmenter == nil {
+		m.appendChat("System", "⚠️ 分词器("+segCfg.Language+")未就绪, 请检查网络后重启")
+	}
 
 	// web 控制面板启用时,在 chat 区给出可点击 / 可复制的地址 —— 浏览器里能新建会话、
 	// 切会话、切权限/沙箱/工作模式,状态与终端实时对齐。
@@ -1166,6 +1203,22 @@ func (m model) submitUserInput(input string) (model, tea.Cmd) {
 	userMsg := m.buildUserMessage(input)
 	m.appendChat("You", input)
 	m.history = append(m.history, userMsg)
+	// 本地主题追踪: 每轮 user 消息后更新主题图(仅分词器启用时)。
+	if m.topicGraph != nil {
+		m.topicGraph.TrackMessage(input, len(m.history)-1)
+		// 话题切换检测: 有意义的旧话题存在, 且当前消息创建了新话题 → 提醒
+		if switched, oldKW, _ := m.topicGraph.TopicSwitched(3); switched {
+			oldLabel := strings.Join(oldKW, " ")
+			m.appendChat("System", fmt.Sprintf(
+				"💡 当前话题与之前[%s]不同, 如需新建会话可输入 /new",
+				oldLabel,
+			))
+		}
+		// 侧重点变化检测: 当前话题积累了足够消息后, 提示会话侧重点
+		if changed, focus := m.topicGraph.FocusChanged(2, &m.lastFocusID); changed && focus != "" {
+			m.appendChat("System", fmt.Sprintf("📌 会话侧重点: %s", focus))
+		}
+	}
 	// 对话还没标题时,用首条用户输入当标题(给 /sessions 列表显示)。
 	// 设了新标题就立刻把会话列表推给 web,否则浏览器一直显示"未命名",要切回来才更新。
 	if m.maybeSetConvTitle(input) {

--- a/tui/session_modal.go
+++ b/tui/session_modal.go
@@ -108,6 +108,17 @@ func (m *model) loadCurrentConversation() {
 			}
 			m.history = gobHistory
 			rebuildChatFromHistory(m.chatContent, gobHistory)
+			// 切会话: 重建主题追踪图, 避免旧会话的 TF-IDF 文档频率污染新会话。
+			if m.topicGraph != nil {
+				m.topicGraph.Rebuild(gobHistory)
+				m.lastFocusID = -1
+			}
+		} else {
+			// 新会话无历史: 重置主题追踪图。
+			if m.topicGraph != nil {
+				m.topicGraph.Rebuild(nil)
+				m.lastFocusID = -1
+			}
 		}
 	}
 	m.refreshViewport()

--- a/tui/view.go
+++ b/tui/view.go
@@ -530,6 +530,9 @@ func (m model) statusFooterLine(_ int) string {
 			if m.turnToolCalls > 0 {
 				s += dim(" · " + strconv.Itoa(m.turnToolCalls) + " " + T("done.tools"))
 			}
+			if badge := m.topicBadge(); badge != "" {
+				s += dim(" · " + badge)
+			}
 			if m.mousePassthrough {
 				s += dim(" · " + T("mouse.passthrough.badge"))
 			}
@@ -539,6 +542,9 @@ func (m model) statusFooterLine(_ int) string {
 		// 这时 deepx 的选区/滚轮都不响应,不说明用户会以为界面坏了。
 		if m.mousePassthrough {
 			return dim(T("mouse.passthrough.badge"))
+		}
+		if badge := m.topicBadge(); badge != "" {
+			return dim(badge)
 		}
 		return ""
 	}
@@ -558,8 +564,23 @@ func (m model) statusFooterLine(_ int) string {
 	if m.mousePassthrough {
 		left += dim(" · " + T("mouse.passthrough.badge"))
 	}
+	if badge := m.topicBadge(); badge != "" {
+		left += dim(" · " + badge)
+	}
 	// 不再右贴 "Esc 中断" —— 输入框 placeholder(misc.input_placeholder)已含,避免重复。
 	return left
+}
+
+// topicBadge 返回当前主题标签, 无主题时返回空。
+func (m model) topicBadge() string {
+	if m.topicGraph == nil {
+		return ""
+	}
+	focus := m.topicGraph.SessionFocus()
+	if focus == "" {
+		return ""
+	}
+	return "📌 " + focus
 }
 
 func statusIcon(s string) string {


### PR DESCRIPTION
新增本地实时主题追踪系统(TopicGraph)和可插拔词典分词器:

### 分词器(Segmenter)
- Segmenter 接口, 支持多语言扩展
- 中文词典分词(正向最大匹配, jieba 词典), 首次使用自动下载
- POS 词性标注过滤虚词(连词/介词/助词/代词等不纳入关键词)
- 单字二元组合并(补偿词典未收录的复合词)
- FMM 算法修复: 长词优先(修复前高频短词会错误替换长词)
- 安全加固: HTTP 30s 超时, 32MB 响应体限制, 缓存目录 0700

### 主题追踪(TopicGraph)
- TF-IDF + 余弦相似度实时追踪对话主题
- 会话侧重点摘要(SessionFocus)
- 话题切换检测: 与会话主导话题比对, 区分"切换"与"扩展"
- 虚词过滤基于 jieba POS 标注
- 会话隔离: /new 切换时 TopicGraph 自动重建

### 配置
- segmenter.yaml 独立配置文件(不污染 model.yaml)
- language: zh 启用中文词典分词(默认不启用,零开销)

